### PR TITLE
feat: allow fractions to define thread limits. eg minThreads: 0.5

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ interface FilledOptions extends Options {
 const kDefaultOptions: FilledOptions = {
   filename: null,
   name: 'default',
-  minThreads: Math.max(cpuCount / 2, 1),
+  minThreads: 0.5,
   maxThreads: cpuCount,
   idleTimeout: 0,
   maxQueue: Infinity,
@@ -937,6 +937,28 @@ class Tinypool extends EventEmitterAsyncResource {
   #pool: ThreadPool
 
   constructor(options: Options = {}) {
+    // convert fractional option values to int
+    if (
+      options.minThreads !== undefined &&
+      options.minThreads > 0 &&
+      options.minThreads < 1
+    ) {
+      options.minThreads = Math.max(
+        1,
+        Math.floor(options.minThreads * cpuCount)
+      )
+    }
+    if (
+      options.maxThreads !== undefined &&
+      options.maxThreads > 0 &&
+      options.maxThreads < 1
+    ) {
+      options.maxThreads = Math.max(
+        1,
+        Math.floor(options.maxThreads * cpuCount)
+      )
+    }
+
     super({ ...options, name: 'Tinypool' })
 
     if (

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,0 +1,50 @@
+import Tinypool from 'tinypool'
+import { cpus } from 'os'
+const cpuCount = cpus().length
+
+const testIf = (condition) => (condition ? test : test.skip)
+
+describe('options', () => {
+  // TODO mock amount instead?
+  testIf(cpuCount > 1)('fractional thread limits can be set', async () => {
+    const min = 0.5
+    const max = 0.75
+    const p = new Tinypool({
+      minThreads: min,
+      maxThreads: max,
+    })
+
+    expect(p.options.minThreads).toBe(Math.floor(cpuCount * min))
+    expect(p.options.maxThreads).toBe(Math.floor(cpuCount * max))
+  })
+
+  test('fractional thread limits result is 1 for very low fractions', async () => {
+    const min = 0.00005
+    const max = 0.00006
+    const p = new Tinypool({
+      minThreads: min,
+      maxThreads: max,
+    })
+
+    expect(p.options.minThreads).toBe(1)
+    expect(p.options.maxThreads).toBe(1)
+  })
+
+  testIf(cpuCount > 2)(
+    'fractional thread limits in the wrong order throw an error',
+    async () => {
+      expect(() => {
+        new Tinypool({
+          minThreads: 0.75,
+          maxThreads: 0.25,
+        })
+      }).toThrow()
+      expect(() => {
+        new Tinypool({
+          minThreads: 0.75,
+          maxThreads: 1,
+        })
+      }).toThrow()
+    }
+  )
+})


### PR DESCRIPTION
as discussed on discord.

I've tried to keep the diff to upstream piscina to a minumum, if this is still to large for you maybe add it to vitest instead?

Didn't see an immediate way to mock the internal cpu amount so the tests use a little testIf helper. github action runners use 4 threads iirc. so it should test all on gh.

