### PR TITLE
fix: optimize the algorithm for cpu count calculation in the linux

### DIFF
--- a/src/physicalCpuCount.ts
+++ b/src/physicalCpuCount.ts
@@ -16,8 +16,17 @@ try {
   const platform = os.platform()
 
   if (platform === 'linux') {
-    const output = exec('cat /proc/cpuinfo | grep "physical id" | sort | wc -l')
-    amount = parseInt(output.trim(), 10)
+    const output1 = exec(
+      'cat /proc/cpuinfo | grep "physical id" | sort |uniq | wc -l'
+    ) // physical cpu number
+    const output2 = exec(
+      'cat /proc/cpuinfo | grep "core id" | sort | uniq | wc -l'
+    ) // physical cpu core number in each cpu
+
+    const physicalCpuAmount = parseInt(output1.trim(), 10)
+    const physicalCoreAmount = parseInt(output2.trim(), 10)
+
+    amount = physicalCpuAmount * physicalCoreAmount
   } else if (platform === 'darwin') {
     const output = exec('sysctl -n hw.physicalcpu_max')
     amount = parseInt(output.trim(), 10)


### PR DESCRIPTION
# Background
- This pr is created as a result of  [discussion](https://github.com/tinylibs/tinypool/discussions/33#discussioncomment-3081868). We found the max thread count when equal to the number of physical cores is the best way, but not before.

# Content
- We use the command `cat /proc/cpuinfo | grep "physical id" | sort |uniq | wc -l` to get the physical CPU number and use the command `cat /proc/cpuinfo | grep "core id" | sort | uniq | wc -l` to get physical CPU core number in each CPU. Finally, we can get the physical CPU cores number by multiplying these two values together.
