### PR TITLE
fix: delete useless plafrom condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Tinypool is a fork of piscina. What we try to achieve in this library, is to eli
 
 - Written in TypeScript, and ESM support only. For Node.js 14.x and higher.
 
+*In case you need more tiny libraries like tinypool or tinyspy, please consider submitting an [RFC](https://github.com/tinylibs/rfcs)*
+
 ## Example
 
 In `main.js`:

--- a/src/physicalCpuCount.ts
+++ b/src/physicalCpuCount.ts
@@ -16,8 +16,17 @@ try {
   const platform = os.platform()
 
   if (platform === 'linux') {
-    const output = exec('cat /proc/cpuinfo | grep "physical id" | sort | wc -l')
-    amount = parseInt(output.trim(), 10)
+    const output1 = exec(
+      'cat /proc/cpuinfo | grep "physical id" | sort |uniq | wc -l'
+    ) // physical cpu number
+    const output2 = exec(
+      'cat /proc/cpuinfo | grep "core id" | sort | uniq | wc -l'
+    ) // physical cpu core number in each cpu
+
+    const physicalCpuAmount = parseInt(output1.trim(), 10)
+    const physicalCoreAmount = parseInt(output2.trim(), 10)
+
+    amount = physicalCpuAmount * physicalCoreAmount
   } else if (platform === 'darwin') {
     const output = exec('sysctl -n hw.physicalcpu_max')
     amount = parseInt(output.trim(), 10)

--- a/src/physicalCpuCount.ts
+++ b/src/physicalCpuCount.ts
@@ -30,7 +30,6 @@ try {
   } else if (platform === 'darwin') {
     const output = exec('sysctl -n hw.physicalcpu_max')
     amount = parseInt(output.trim(), 10)
-    // @ts-ignore
   } else if (platform === 'win32') {
     // windows takes too long, so let's drop the support
     throw new Error()

--- a/src/physicalCpuCount.ts
+++ b/src/physicalCpuCount.ts
@@ -31,7 +31,7 @@ try {
     const output = exec('sysctl -n hw.physicalcpu_max')
     amount = parseInt(output.trim(), 10)
     // @ts-ignore
-  } else if (platform === 'windows' || platform === 'win32') {
+  } else if (platform === 'win32') {
     // windows takes too long, so let's drop the support
     throw new Error()
   } else {


### PR DESCRIPTION
# background
- os.platform() will never be equal to 'windows', so it is a useless condition in the changed file.
- OS API Document: http://nodejs.cn/api-v16/os.html#osplatform

# changes
- delete this condition