### PR TITLE
Use top-level await in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,8 @@ const pool = new Tinypool({
   filename: new URL('./worker.js', import.meta.url).href,
 })
 
-;(async function () {
-  const result = await pool.run({ a: 4, b: 6 })
-  console.log(result) // Prints 10
-})()
+const result = await pool.run({ a: 4, b: 6 })
+console.log(result) // Prints 10
 ```
 
 In `worker.js`:


### PR DESCRIPTION
It should be safe to recommend this as we target Node 14 or newer, and this was added in Node 14.8. Worst case, the user gets an error and learns to wrap it in a function as needed.