### PR TITLE
fix workerIds when maxThreads is undefined at passed options.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -591,7 +591,7 @@ class ThreadPool {
     }
 
     this.workerIds = new Map(
-      new Array(options.maxThreads).fill(0).map((_, i) => [i + 1, true])
+      new Array(this.options.maxThreads).fill(0).map((_, i) => [i + 1, true])
     )
 
     this.workers = new AsynchronouslyCreatedResourcePool<WorkerInfo>(


### PR DESCRIPTION
Reproduction:

pool.mjs:
```
import Tinypool from 'tinypool';

const pool = new Tinypool({
  filename: new URL('./worker-id.mjs', import.meta.url).href,
});
pool.run();
pool.run();
pool.run();
pool.run();
pool.run();
```

worker-id.mjs
```
import { workerId } from 'tinypool';

export default function () {
  console.log('workerId', workerId);
}
```

`node pool.mjs`:
```
% node pool.mjs
workerId undefined
workerId undefined
workerId undefined
workerId 1
workerId undefined
```