### PR TITLE
chore: remove unnecessary import of 'path'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ _In case you need more tiny libraries like tinypool or tinyspy, please consider 
 In `main.js`:
 
 ```js
-import path from 'path'
 import Tinypool from 'tinypool'
 
 const pool = new Tinypool({


### PR DESCRIPTION
There is no need to use the `path` module since you are using `new URL` and `import.meta.url` to resolve the file location instead.