### PR TITLE
chore: add benchmark for worker isolation

### DIFF
--- a/benchmark/fixtures/add.mjs
+++ b/benchmark/fixtures/add.mjs
@@ -1,2 +1,1 @@
-'use strict'
 export default ({ a, b }) => a + b

--- a/benchmark/fixtures/wrap-add.mjs
+++ b/benchmark/fixtures/wrap-add.mjs
@@ -1,0 +1,7 @@
+import { parentPort } from 'node:worker_threads'
+
+import add from './add.mjs'
+
+parentPort.on('message', (message) => {
+  parentPort.postMessage(add(message))
+})

--- a/benchmark/isolate-benchmark.mjs
+++ b/benchmark/isolate-benchmark.mjs
@@ -1,0 +1,65 @@
+/*
+ * Benchmark for testing whether Tinypool's worker creation and teardown is expensive.
+ */
+import { cpus } from 'node:os'
+import { Worker } from 'node:worker_threads'
+
+import Tinypool from '../dist/esm/index.js'
+
+const THREADS = cpus().length - 1
+const ROUNDS = 5_000
+
+await logTime('Tinypool', runTinypool)
+await logTime('Worker threads', runWorkerThreads)
+
+async function runTinypool() {
+  const pool = new Tinypool({
+    filename: new URL('./fixtures/add.mjs', import.meta.url).href,
+    isolateWorkers: true,
+    minThreads: THREADS,
+    maxThreads: THREADS,
+  })
+
+  await Promise.all(
+    Array(ROUNDS)
+      .fill()
+      .map(() => pool.run({ a: 1, b: 2 }))
+  )
+}
+
+async function runWorkerThreads() {
+  async function task() {
+    const worker = new Worker('./fixtures/wrap-add.mjs')
+    worker.postMessage({ a: 1, b: 2 })
+
+    await new Promise((resolve, reject) =>
+      worker.on('message', (sum) => (sum === 3 ? resolve() : reject('Not 3')))
+    )
+
+    await worker.terminate()
+  }
+
+  const pool = Array(ROUNDS).fill(task)
+
+  async function execute() {
+    const task = pool.shift()
+
+    if (task) {
+      await task()
+      return execute()
+    }
+  }
+
+  await Promise.all(
+    Array(THREADS)
+      .fill(execute)
+      .map((task) => task())
+  )
+}
+
+async function logTime(label, method) {
+  const start = process.hrtime.bigint()
+  await method()
+  const end = process.hrtime.bigint()
+  console.log(label, 'took', ((end - start) / 1_000_000n).toString(), 'ms')
+}

--- a/benchmark/simple-benchmark.mjs
+++ b/benchmark/simple-benchmark.mjs
@@ -1,9 +1,9 @@
-'use strict'
-const { Piscina } = require('..')
-const { resolve } = require('path')
+import Tinypool from '../dist/esm/index.js'
 
 async function simpleBenchmark({ duration = 10000 } = {}) {
-  const pool = new Piscina({ filename: resolve(__dirname, 'fixtures/add.js') })
+  const pool = new Tinypool({
+    filename: new URL('./fixtures/add.mjs', import.meta.url).href,
+  })
   let done = 0
 
   const results = []
@@ -14,7 +14,7 @@ async function simpleBenchmark({ duration = 10000 } = {}) {
 
   async function scheduleTasks() {
     while ((process.hrtime.bigint() - start) / 1_000_000n < duration) {
-      await pool.runTask({ a: 4, b: 6 })
+      await pool.run({ a: 4, b: 6 })
       done++
     }
   }
@@ -24,6 +24,5 @@ async function simpleBenchmark({ duration = 10000 } = {}) {
   return (done / duration) * 1e3
 }
 
-simpleBenchmark().then((opsPerSecond) => {
-  console.log(`opsPerSecond: ${opsPerSecond}`)
-})
+const opsPerSecond = await simpleBenchmark()
+console.log(`opsPerSecond: ${opsPerSecond}`)


### PR DESCRIPTION
- Fixes broken `benchmark/simple-benchmark.js` by converting it to ESM and changing `pool`'s method
- Adds new benchmark for testing whether Tinypool does something expensive when creating and terminating workers.

