### PR TITLE
feat: `pool.cancelPendingTasks` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,20 @@ export default ({ a, b }) => {
 
 We have a similar API to Piscina, so for more information, you can read Piscina's detailed [documentation](https://github.com/piscinajs/piscina#piscina---the-nodejs-worker-pool) and apply the same techniques here.
 
-###### Additional Options
+### Tinypool specific APIs
+
+#### Pool constructor options
 
 - `isolateWorkers`: Default to `false`. Always starts with a fresh worker when running tasks to isolate the environment.
-- `workerId`: Each worker now has an id ( <= `maxThreads`) that can be imported
-  from `tinypool` in the worker itself (or `process.__tinypool_state__.workerId`)
 - `terminateTimeout`: Defaults to `null`. If terminating a worker takes `terminateTimeout` amount of milliseconds to execute, an error is raised.
+
+#### Pool methods
+
+- `cancelPendingTasks()`: Gracefully cancels all pending tasks without stopping or interfering with on-going tasks. This method is useful when your tasks may have side effects and should not be terminated forcefully during task execution. If your tasks don't have any side effects you may want to use [`{ signal }`](https://github.com/piscinajs/piscina#cancelable-tasks) option for forcefully terminating all tasks, including the on-going ones, instead.
+
+#### Exports
+
+- `workerId`: Each worker now has an id ( <= `maxThreads`) that can be imported from `tinypool` in the worker itself (or `process.__tinypool_state__.workerId`).
 
 ## Authors
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -70,6 +70,7 @@ export interface Transferable {
 
 export interface Task {
   readonly [kQueueOptions]: object | null
+  cancel(): void
 }
 
 export interface TaskQueue {
@@ -77,6 +78,7 @@ export interface TaskQueue {
   shift(): Task | null
   remove(task: Task): void
   push(task: Task): void
+  cancel(): void
 }
 
 export function isTaskQueue(value: any): boolean {


### PR DESCRIPTION
- Fixes #52 

Here is the same test case with `signal` usage to demonstrate the issue clearly:

<details>

```ts
import EventEmitter from 'events'

test('queued tasks can be aborted', async () => {
  const pool = new Tinypool({
    filename: resolve(__dirname, 'fixtures/sleep.js'),
    minThreads: 0,
    maxThreads: 1,
  })

  const signal = new EventEmitter()

  const time = 500
  const promises = []
  let finishedTasks = 0
  let cancelledTasks = 0

  for (const _ of Array(10).fill(0)) {
    const promise = pool
      .run({ time }, { signal })
      .then(() => {
        finishedTasks++
      })
      .catch((error) => {
        if (error.message !== 'The task has been aborted') {
          throw error
        }
        cancelledTasks++
      })
    promises.push(promise)
  }

  // Wait for task to start
  await new Promise((resolve) => setTimeout(resolve, time / 2))
  expect(pool.queueSize).toBe(9)

  // One task is running, cancel the pending ones
  signal.emit('abort')

  // The first task should still be on-going, pending ones should be cancelled
  expect(finishedTasks).toBe(0)
  expect(pool.queueSize).toBe(0)

  await Promise.all(promises)

  expect({ finishedTasks, cancelledTasks }).toEqual({
    finishedTasks: 1,
    cancelledTasks: 9,
  })
})
```

</details>