### PR TITLE
feat: add `maxMemoryLimitBeforeRecycle` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ We have a similar API to Piscina, so for more information, you can read Piscina'
 
 #### Pool constructor options
 
-- `isolateWorkers`: Default to `false`. Always starts with a fresh worker when running tasks to isolate the environment.
-- `terminateTimeout`: Defaults to `null`. If terminating a worker takes `terminateTimeout` amount of milliseconds to execute, an error is raised.
+- `isolateWorkers`: Disabled by default. Always starts with a fresh worker when running tasks to isolate the environment.
+- `terminateTimeout`: Disabled by default. If terminating a worker takes `terminateTimeout` amount of milliseconds to execute, an error is raised.
+- `maxMemoryLimitBeforeRecycle`: Disabled by default. When defined, the worker's heap memory usage is compared against this value after task has been finished. If the current memory usage exceeds this limit, worker is terminated and a new one is started to take its place. This option is useful when your tasks leak memory and you don't want to enable `isolateWorkers` option.
 
 #### Pool methods
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -23,6 +23,7 @@ export interface ResponseMessage {
   taskId: number
   result: any
   error: unknown | null
+  usedMemory: number
 }
 
 export interface TinypoolPrivateData {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -172,6 +172,7 @@ function onMessage(
         taskId,
         result: result,
         error: null,
+        usedMemory: process.memoryUsage().heapUsed,
       }
 
       // If the task used e.g. console.log(), wait for the stream to drain
@@ -191,6 +192,7 @@ function onMessage(
         // It may be worth taking a look at the error cloning algorithm we
         // use in Node.js core here, it's quite a bit more flexible
         error,
+        usedMemory: process.memoryUsage().heapUsed,
       }
     }
     currentTasks--

--- a/test/fixtures/leak-memory.js
+++ b/test/fixtures/leak-memory.js
@@ -1,0 +1,17 @@
+export let leaks = []
+
+/**
+ * Leak some memory to test memory limit usage.
+ * The argument `bytes` is not 100% accurate of the leaked bytes but good enough.
+ */
+export default function run(bytes) {
+  const before = process.memoryUsage().heapUsed
+
+  for (const _ of Array(bytes).fill()) {
+    leaks.push(new SharedArrayBuffer(1024))
+  }
+  const after = process.memoryUsage().heapUsed
+  const diff = after - before
+
+  console.log(`Leaked: ${diff}. Heap used: ${process.memoryUsage().heapUsed}`)
+}


### PR DESCRIPTION
- Closes #56

The implementation is highly inspired by `jest-worker`'s `idleMemoryLimit` option. 

Each worker reports their `process.memoryUsage().heapUsed` to main thread when they have finished the current task. Main thread compares this limit to pool's new memory limit option and decides whether worker should be terminated and replaced with new one.