### PR TITLE
fix: ensure that `minThreads` is respected when using `isolateWorkers`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -894,6 +894,7 @@ class ThreadPool {
         // When `isolateWorkers` is enabled, remove the worker after task is finished
         if (this.options.isolateWorkers && taskInfo.workerInfo) {
           this._removeWorker(taskInfo.workerInfo)
+            .then(() => this._ensureMinimumWorkers())
             .then(() => this._ensureEnoughWorkersForTaskQueue())
             .then(() => resolve(result))
             .catch(reject)

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -212,6 +212,29 @@ test('workerId should never be more than maxThreads', async () => {
   await sleep(300)
 })
 
+test('worker count should never be below minThreads when using isolateWorkers', async () => {
+  const minThreads = 4
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/workerId.js'),
+    isolateWorkers: true,
+    minThreads,
+  })
+  await pool.run({})
+  expect(pool.threads.length).toBe(minThreads)
+  await pool.run({})
+  expect(pool.threads.length).toBe(minThreads)
+  await pool.run({})
+  expect(pool.threads.length).toBe(minThreads)
+  await pool.run({})
+  expect(pool.threads.length).toBe(minThreads)
+  await pool.run({})
+  expect(pool.threads.length).toBe(minThreads)
+  await pool.run({})
+  expect(pool.threads.length).toBe(minThreads)
+
+  await sleep(300)
+})
+
 test('workerId should never be duplicated', async () => {
   const maxThreads = cpus().length + 4
   // console.log('maxThreads', maxThreads)


### PR DESCRIPTION
I noticed that when using `isolateWorkers: true`, `minThreads` is not respected correctly.

After every worker run the worker is terminated, but no new workers are started unless the task-queue is bigger than the worker count.

This fix ensures that after a worker is terminated we ensure that we have the minimum amount of workers running.

Let me know what you think about this. :)