### PR TITLE
fix: dont mark recycled workers as available

### DIFF
--- a/test/resource-limits.test.ts
+++ b/test/resource-limits.test.ts
@@ -74,3 +74,20 @@ test('worker is recycled after reaching maxMemoryLimitBeforeRecycle', async () =
   // Thread should have been recycled
   expect(finalThreadId).not.toBe(originalWorkerId)
 })
+
+test('recycled workers should not crash pool (regression)', async () => {
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/leak-memory.js'),
+    maxMemoryLimitBeforeRecycle: 10,
+    isolateWorkers: false,
+    minThreads: 2,
+    maxThreads: 2,
+  })
+
+  // This should not crash the pool
+  await Promise.all(
+    Array(10)
+      .fill(0)
+      .map(() => pool.run(10_000))
+  )
+})


### PR DESCRIPTION
- Fixes https://github.com/tinylibs/tinypool/pull/58#issuecomment-1611266670
- Tested with Vitest's VM isolation PR. Crashes are now gone.