### PR TITLE
feat: support `runtime` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tinypool is a fork of piscina. What we try to achieve in this library, is to eli
 - ✅ Minimal
 - ✅ No dependencies
 - ✅ Physical cores instead of Logical cores with [physical-cpu-count](https://www.npmjs.com/package/physical-cpu-count)
+- ✅ Supports `worker_threads` and `child_process`
 - ❌ No utilization
 - ❌ No NAPI
 
@@ -17,26 +18,149 @@ _In case you need more tiny libraries like tinypool or tinyspy, please consider 
 
 ## Example
 
-In `main.js`:
+### Using `node:worker_threads`
+
+#### Basic usage
 
 ```js
+// main.mjs
 import Tinypool from 'tinypool'
 
 const pool = new Tinypool({
-  filename: new URL('./worker.js', import.meta.url).href,
+  filename: new URL('./worker.mjs', import.meta.url).href,
 })
-
 const result = await pool.run({ a: 4, b: 6 })
 console.log(result) // Prints 10
 ```
 
-In `worker.js`:
-
 ```js
+// worker.mjs
 export default ({ a, b }) => {
   return a + b
 }
 ```
+
+#### Main thread <-> worker thread communication
+
+<details>
+  <summary>See code</summary>
+
+```js
+// main.mjs
+import Tinypool from 'tinypool'
+import { MessageChannel } from 'node:worker_threads'
+
+const pool = new Tinypool({
+  filename: new URL('./worker.mjs', import.meta.url).href,
+})
+const { port1, port2 } = new MessageChannel()
+const promise = pool.run({ port: port1 }, { transferList: [port1] })
+
+port2.on('message', (message) => console.log('Main thread received:', message))
+setTimeout(() => port2.postMessage('Hello from main thread!'), 1000)
+
+await promise
+
+port1.close()
+port2.close()
+```
+
+```js
+// worker.mjs
+export default ({ port }) => {
+  return new Promise((resolve) => {
+    port.on('message', (message) => {
+      console.log('Worker received:', message)
+
+      port.postMessage('Hello from worker thread!')
+      resolve()
+    })
+  })
+}
+```
+
+</details>
+
+### Using `node:child_process`
+
+#### Basic usage
+
+<details>
+  <summary>See code</summary>
+
+```js
+// main.mjs
+import Tinypool from 'tinypool'
+
+const pool = new Tinypool({
+  runtime: 'child_process',
+  filename: new URL('./worker.mjs', import.meta.url).href,
+})
+const result = await pool.run({ a: 4, b: 6 })
+console.log(result) // Prints 10
+```
+
+```js
+// worker.mjs
+export default ({ a, b }) => {
+  return a + b
+}
+```
+
+</details>
+
+#### Main process <-> worker process communication
+
+<details>
+  <summary>See code</summary>
+
+```js
+// main.mjs
+import Tinypool from 'tinypool'
+
+const pool = new Tinypool({
+  runtime: 'child_process',
+  filename: new URL('./worker.mjs', import.meta.url).href,
+})
+
+const messages = []
+const listeners = []
+const channel = {
+  onMessage: (listener) => listeners.push(listener),
+  postMessage: (message) => messages.push(message),
+}
+
+const promise = pool.run({}, { channel })
+
+// Send message to worker
+setTimeout(
+  () => listeners.forEach((listener) => listener('Hello from main process')),
+  1000
+)
+
+// Wait for task to finish
+await promise
+
+console.log(messages)
+// [{ received: 'Hello from main process', response: 'Hello from worker' }]
+```
+
+```js
+// worker.mjs
+export default async function run() {
+  return new Promise((resolve) => {
+    process.on('message', (message) => {
+      // Ignore Tinypool's internal messages
+      if (message?.__tinypool_worker_message__) return
+
+      process.send({ received: message, response: 'Hello from worker' })
+      resolve()
+    })
+  })
+}
+```
+
+</details>
 
 ## API
 
@@ -49,11 +173,14 @@ We have a similar API to Piscina, so for more information, you can read Piscina'
 - `isolateWorkers`: Disabled by default. Always starts with a fresh worker when running tasks to isolate the environment.
 - `terminateTimeout`: Disabled by default. If terminating a worker takes `terminateTimeout` amount of milliseconds to execute, an error is raised.
 - `maxMemoryLimitBeforeRecycle`: Disabled by default. When defined, the worker's heap memory usage is compared against this value after task has been finished. If the current memory usage exceeds this limit, worker is terminated and a new one is started to take its place. This option is useful when your tasks leak memory and you don't want to enable `isolateWorkers` option.
+- `runtime`: Used to pick worker runtime. Default value is `worker_threads`.
+  - `worker_threads`: Runs workers in [`node:worker_threads`](https://nodejs.org/api/worker_threads.html). For `main thread <-> worker thread` communication you can use [`MessagePort`](https://nodejs.org/api/worker_threads.html#class-messageport) in the `pool.run()` method's [`transferList` option](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist). See [example](#main-thread---worker-thread-communication).
+  - `child_process`: Runs workers in [`node:child_process`](https://nodejs.org/api/child_process.html). For `main thread <-> worker process` communication you can use `TinypoolChannel` in the `pool.run()` method's `channel` option. For filtering out the Tinypool's internal messages see `TinypoolWorkerMessage`. See [example](#main-process---worker-process-communication).
 
 #### Pool methods
 
 - `cancelPendingTasks()`: Gracefully cancels all pending tasks without stopping or interfering with on-going tasks. This method is useful when your tasks may have side effects and should not be terminated forcefully during task execution. If your tasks don't have any side effects you may want to use [`{ signal }`](https://github.com/piscinajs/piscina#cancelable-tasks) option for forcefully terminating all tasks, including the on-going ones, instead.
-- `recycleWorkers()`: Waits for all current tasks to finish and re-creates all workers. Can be used to force isolation imperatively even when `isolateWorkers` is disabled.
+- `recycleWorkers(options)`: Waits for all current tasks to finish and re-creates all workers. Can be used to force isolation imperatively even when `isolateWorkers` is disabled. Accepts `{ runtime }` option as argument.
 
 #### Exports
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
       ".ts"
     ],
     "testRegex": "test.(js|ts|tsx)$",
+    "verbose": true,
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coverageReporters": [

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,46 @@
-import type { MessagePort } from 'worker_threads'
+import type { MessagePort, TransferListItem } from 'worker_threads'
+
+/** Channel for communicating between main thread and workers */
+export interface TinypoolChannel {
+  /** Workers subscribing to messages */
+  onMessage(callback: (message: any) => void): void
+
+  /** Called with worker's messages */
+  postMessage(message: any): void
+}
+
+export interface TinypoolWorker {
+  runtime: string
+  initialize(options: {
+    env?: Record<string, string>
+    argv?: string[]
+    execArgv?: string[]
+    resourceLimits?: any
+    workerData?: TinypoolData
+    trackUnmanagedFds?: boolean
+  }): void
+  terminate(): Promise<any>
+  postMessage(message: any, transferListItem?: TransferListItem[]): void
+  setChannel?: (channel: TinypoolChannel) => void
+  on(event: string, listener: (...args: any[]) => void): void
+  once(event: string, listener: (...args: any[]) => void): void
+  emit(event: string, ...data: any[]): void
+  ref?: () => void
+  unref?: () => void
+  threadId: number
+}
+
+/**
+ * Tinypool's internal messaging between main thread and workers.
+ * - Utilizers can use `__tinypool_worker_message__` property to identify
+ *   these messages and ignore them.
+ */
+export interface TinypoolWorkerMessage<
+  T extends 'port' | 'pool' = 'port' | 'pool'
+> {
+  __tinypool_worker_message__: true
+  source: T
+}
 
 export interface StartupMessage {
   filename: string | null

--- a/src/entry/process.ts
+++ b/src/entry/process.ts
@@ -1,0 +1,110 @@
+import { stderr, stdout } from 'src/utils'
+import {
+  ReadyMessage,
+  RequestMessage,
+  ResponseMessage,
+  StartupMessage,
+  TinypoolWorkerMessage,
+} from '../common'
+import { getHandler, throwInNextTick } from './utils'
+
+type IncomingMessage =
+  | (StartupMessage & TinypoolWorkerMessage<'pool'>)
+  | (RequestMessage & TinypoolWorkerMessage<'port'>)
+
+type OutgoingMessage =
+  | (ReadyMessage & TinypoolWorkerMessage<'pool'>)
+  | (ResponseMessage & TinypoolWorkerMessage<'port'>)
+
+process.__tinypool_state__ = {
+  isChildProcess: true,
+  isTinypoolWorker: true,
+  workerData: null,
+  workerId: process.pid,
+}
+
+process.on('message', (message: IncomingMessage) => {
+  // Message was not for port or pool
+  // It's likely end-users own communication between main and worker
+  if (!message || !message.__tinypool_worker_message__) return
+
+  if (message.source === 'pool') {
+    const { filename, name } = message
+
+    ;(async function () {
+      if (filename !== null) {
+        await getHandler(filename, name)
+      }
+
+      process.send!(<OutgoingMessage>{
+        ready: true,
+        source: 'pool',
+        __tinypool_worker_message__: true,
+      })
+    })().catch(throwInNextTick)
+
+    return
+  }
+
+  if (message.source === 'port') {
+    return onMessage(message).catch(throwInNextTick)
+  }
+
+  throw new Error(`Unexpected TinypoolWorkerMessage ${JSON.stringify(message)}`)
+})
+
+async function onMessage(message: IncomingMessage & { source: 'port' }) {
+  const { taskId, task, filename, name } = message
+  let response: OutgoingMessage & Pick<typeof message, 'source'>
+
+  try {
+    const handler = await getHandler(filename, name)
+    if (handler === null) {
+      throw new Error(`No handler function exported from ${filename}`)
+    }
+    const result = await handler(task)
+    response = {
+      source: 'port',
+      __tinypool_worker_message__: true,
+      taskId,
+      result,
+      error: null,
+      usedMemory: process.memoryUsage().heapUsed,
+    }
+
+    // If the task used e.g. console.log(), wait for the stream to drain
+    // before potentially entering the `Atomics.wait()` loop, and before
+    // returning the result so that messages will always be printed even
+    // if the process would otherwise be ready to exit.
+    if (stdout()?.writableLength! > 0) {
+      await new Promise((resolve) => process.stdout.write('', resolve))
+    }
+    if (stderr()?.writableLength! > 0) {
+      await new Promise((resolve) => process.stderr.write('', resolve))
+    }
+  } catch (error) {
+    response = {
+      source: 'port',
+      __tinypool_worker_message__: true,
+      taskId,
+      result: null,
+      error: serializeError(error),
+      usedMemory: process.memoryUsage().heapUsed,
+    }
+  }
+
+  process.send!(response)
+}
+
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      ...error,
+      name: error.name,
+      stack: error.stack,
+      message: error.message,
+    }
+  }
+
+  return String(error)
+}

--- a/src/entry/utils.ts
+++ b/src/entry/utils.ts
@@ -1,0 +1,74 @@
+import { pathToFileURL } from 'url'
+
+// Get `import(x)` as a function that isn't transpiled to `require(x)` by
+// TypeScript for dual ESM/CJS support.
+// Load this lazily, so that there is no warning about the ESM loader being
+// experimental (on Node v12.x) until we actually try to use it.
+let importESMCached: (specifier: string) => Promise<any> | undefined
+
+function getImportESM() {
+  if (importESMCached === undefined) {
+    // eslint-disable-next-line no-new-func
+    importESMCached = new Function(
+      'specifier',
+      'return import(specifier)'
+    ) as typeof importESMCached
+  }
+  return importESMCached
+}
+
+const handlerCache: Map<string, Function> = new Map()
+
+// Look up the handler function that we call when a task is posted.
+// This is either going to be "the" export from a file, or the default export.
+export async function getHandler(
+  filename: string,
+  name: string
+): Promise<Function | null> {
+  let handler = handlerCache.get(`${filename}/${name}`)
+  if (handler !== undefined) {
+    return handler
+  }
+
+  try {
+    // With our current set of TypeScript options, this is transpiled to
+    // `require(filename)`.
+    const handlerModule = await import(filename)
+
+    // Check if the default export is an object, because dynamic import
+    // resolves with `{ default: { default: [Function] } }` for CJS modules.
+    handler =
+      (typeof handlerModule.default !== 'function' && handlerModule.default) ||
+      handlerModule
+
+    if (typeof handler !== 'function') {
+      handler = await (handler as any)[name]
+    }
+  } catch {}
+  if (typeof handler !== 'function') {
+    handler = await getImportESM()(pathToFileURL(filename).href)
+    if (typeof handler !== 'function') {
+      handler = await (handler as any)[name]
+    }
+  }
+  if (typeof handler !== 'function') {
+    return null
+  }
+
+  // Limit the handler cache size. This should not usually be an issue and is
+  // only provided for pathological cases.
+  if (handlerCache.size > 1000) {
+    // @ts-ignore
+    const [[key]] = handlerCache
+    handlerCache.delete(key)
+  }
+
+  handlerCache.set(`${filename}/${name}`, handler)
+  return handler
+}
+
+export function throwInNextTick(error: Error) {
+  process.nextTick(() => {
+    throw error
+  })
+}

--- a/src/entry/worker.ts
+++ b/src/entry/worker.ts
@@ -4,7 +4,6 @@ import {
   receiveMessageOnPort,
   workerData as tinypoolData,
 } from 'worker_threads'
-import { pathToFileURL } from 'url'
 import {
   ReadyMessage,
   RequestMessage,
@@ -16,83 +15,20 @@ import {
   isMovable,
   kTransferable,
   kValue,
-} from './common'
-import { stderr, stdout } from './utils'
+} from '../common'
+import { stderr, stdout } from '../utils'
+import { getHandler, throwInNextTick } from './utils'
 
 const [tinypoolPrivateData, workerData] = tinypoolData as TinypoolData
 
 process.__tinypool_state__ = {
   isWorkerThread: true,
+  isTinypoolWorker: true,
   workerData: workerData,
   workerId: tinypoolPrivateData.workerId,
 }
 
-const handlerCache: Map<string, Function> = new Map()
 let useAtomics: boolean = process.env.PISCINA_DISABLE_ATOMICS !== '1'
-
-// Get `import(x)` as a function that isn't transpiled to `require(x)` by
-// TypeScript for dual ESM/CJS support.
-// Load this lazily, so that there is no warning about the ESM loader being
-// experimental (on Node v12.x) until we actually try to use it.
-let importESMCached: (specifier: string) => Promise<any> | undefined
-function getImportESM() {
-  if (importESMCached === undefined) {
-    // eslint-disable-next-line no-new-func
-    importESMCached = new Function(
-      'specifier',
-      'return import(specifier)'
-    ) as typeof importESMCached
-  }
-  return importESMCached
-}
-
-// Look up the handler function that we call when a task is posted.
-// This is either going to be "the" export from a file, or the default export.
-async function getHandler(
-  filename: string,
-  name: string
-): Promise<Function | null> {
-  let handler = handlerCache.get(`${filename}/${name}`)
-  if (handler !== undefined) {
-    return handler
-  }
-
-  try {
-    // With our current set of TypeScript options, this is transpiled to
-    // `require(filename)`.
-    const handlerModule = await import(filename)
-
-    // Check if the default export is an object, because dynamic import
-    // resolves with `{ default: { default: [Function] } }` for CJS modules.
-    handler =
-      (typeof handlerModule.default !== 'function' && handlerModule.default) ||
-      handlerModule
-
-    if (typeof handler !== 'function') {
-      handler = await (handler as any)[name]
-    }
-  } catch {}
-  if (typeof handler !== 'function') {
-    handler = await getImportESM()(pathToFileURL(filename).href)
-    if (typeof handler !== 'function') {
-      handler = await (handler as any)[name]
-    }
-  }
-  if (typeof handler !== 'function') {
-    return null
-  }
-
-  // Limit the handler cache size. This should not usually be an issue and is
-  // only provided for pathological cases.
-  if (handlerCache.size > 1000) {
-    // @ts-ignore
-    const [[key]] = handlerCache
-    handlerCache.delete(key)
-  }
-
-  handlerCache.set(`${filename}/${name}`, handler)
-  return handler
-}
 
 // We should only receive this message once, when the Worker starts. It gives
 // us the MessagePort used for receiving tasks, a SharedArrayBuffer for fast
@@ -101,7 +37,9 @@ async function getHandler(
 parentPort!.on('message', (message: StartupMessage) => {
   useAtomics =
     process.env.PISCINA_DISABLE_ATOMICS === '1' ? false : message.useAtomics
+
   const { port, sharedBuffer, filename, name } = message
+
   ;(async function () {
     if (filename !== null) {
       await getHandler(filename, name)
@@ -204,10 +142,4 @@ function onMessage(
     Atomics.add(sharedBuffer, kResponseCountField, 1)
     atomicsWaitLoop(port, sharedBuffer)
   })().catch(throwInNextTick)
-}
-
-function throwInNextTick(error: Error) {
-  process.nextTick(() => {
-    throw error
-  })
 }

--- a/src/runtime/process-worker.ts
+++ b/src/runtime/process-worker.ts
@@ -1,0 +1,101 @@
+import { ChildProcess, fork } from 'child_process'
+import { MessagePort, TransferListItem } from 'worker_threads'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import {
+  TinypoolChannel,
+  TinypoolWorker,
+  TinypoolWorkerMessage,
+} from '../common'
+
+const __tinypool_worker_message__ = 'true'
+
+export default class ProcessWorker implements TinypoolWorker {
+  name = 'ProcessWorker'
+  runtime = 'child_process'
+  process!: ChildProcess
+  threadId!: number
+  port?: MessagePort
+  channel?: TinypoolChannel
+
+  initialize(options: Parameters<TinypoolWorker['initialize']>[0]) {
+    const __dirname = dirname(fileURLToPath(import.meta.url))
+
+    this.process = fork(resolve(__dirname, './entry/process.js'), options)
+    this.threadId = this.process.pid!
+  }
+
+  async terminate() {
+    return this.process.kill()
+  }
+
+  setChannel(channel: TinypoolChannel) {
+    this.channel = channel
+
+    // Mirror channel's messages to process
+    this.channel.onMessage((message: any) => {
+      this.process.send(message)
+    })
+  }
+
+  postMessage(message: any, transferListItem?: Readonly<TransferListItem[]>) {
+    transferListItem?.forEach((item) => {
+      if (item instanceof MessagePort) {
+        this.port = item
+      }
+    })
+
+    // Mirror port's messages to process
+    if (this.port) {
+      this.port.on('message', (message) =>
+        this.process.send(<TinypoolWorkerMessage<'port'>>{
+          ...message,
+          source: 'port',
+          __tinypool_worker_message__,
+        })
+      )
+    }
+
+    return this.process.send(<TinypoolWorkerMessage<'pool'>>{
+      ...message,
+      source: 'pool',
+      __tinypool_worker_message__,
+    })
+  }
+
+  on(event: string, callback: (...args: any[]) => void) {
+    return this.process.on(event, (data: TinypoolWorkerMessage) => {
+      if (!data || !data.__tinypool_worker_message__) {
+        return this.channel?.postMessage(data)
+      }
+
+      if (data.source === 'pool') {
+        callback(data)
+      } else if (data.source === 'port') {
+        this.port!.postMessage(data)
+      }
+    })
+  }
+
+  once(event: string, callback: (...args: any[]) => void) {
+    return this.process.once(event, callback)
+  }
+
+  emit(event: string, ...data: any[]) {
+    return this.process.emit(event, ...data)
+  }
+
+  ref() {
+    return this.process.ref()
+  }
+
+  unref() {
+    this.port?.unref()
+
+    // The forked child_process adds event listener on `process.on('message)`.
+    // This requires manual unreffing of its channel.
+    this.process.channel?.unref()
+
+    return this.process.unref()
+  }
+}

--- a/src/runtime/thread-worker.ts
+++ b/src/runtime/thread-worker.ts
@@ -1,0 +1,52 @@
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+import { TransferListItem, Worker } from 'worker_threads'
+import { TinypoolWorker } from '../common'
+
+export default class ThreadWorker implements TinypoolWorker {
+  name = 'ThreadWorker'
+  runtime = 'worker_threads'
+  thread!: Worker
+  threadId!: number
+
+  initialize(options: Parameters<TinypoolWorker['initialize']>[0]) {
+    const __dirname = dirname(fileURLToPath(import.meta.url))
+
+    this.thread = new Worker(resolve(__dirname, './entry/worker.js'), options)
+    this.threadId = this.thread.threadId
+  }
+
+  async terminate() {
+    return this.thread.terminate()
+  }
+
+  postMessage(message: any, transferListItem?: Readonly<TransferListItem[]>) {
+    return this.thread.postMessage(message, transferListItem)
+  }
+
+  on(event: string, callback: (...args: any[]) => void) {
+    return this.thread.on(event, callback)
+  }
+
+  once(event: string, callback: (...args: any[]) => void) {
+    return this.thread.once(event, callback)
+  }
+
+  emit(event: string, ...data: any[]) {
+    return this.thread.emit(event, ...data)
+  }
+
+  ref() {
+    return this.thread.ref()
+  }
+
+  unref() {
+    return this.thread.unref()
+  }
+
+  setChannel() {
+    throw new Error(
+      "{ runtime: 'worker_threads' } doesn't support channel. Use transferListItem instead."
+    )
+  }
+}

--- a/test/fixtures/child_process-communication.mjs
+++ b/test/fixtures/child_process-communication.mjs
@@ -1,0 +1,13 @@
+export default async function run() {
+  let resolve
+  const promise = new Promise((r) => (resolve = r))
+
+  process.send('Child process started')
+
+  process.on('message', (message) => {
+    process.send({ received: message, response: 'Hello from worker' })
+    resolve()
+  })
+
+  await promise
+}

--- a/test/fixtures/leak-memory.js
+++ b/test/fixtures/leak-memory.js
@@ -1,3 +1,6 @@
+/** Enable to see memory leak logging */
+const logOutput = false
+
 export let leaks = []
 
 /**
@@ -13,5 +16,7 @@ export default function run(bytes) {
   const after = process.memoryUsage().heapUsed
   const diff = after - before
 
-  console.log(`Leaked: ${diff}. Heap used: ${process.memoryUsage().heapUsed}`)
+  if (logOutput) {
+    console.log(`Leaked: ${diff}. Heap used: ${process.memoryUsage().heapUsed}`)
+  }
 }

--- a/test/isolation.test.ts
+++ b/test/isolation.test.ts
@@ -4,78 +4,86 @@ import { fileURLToPath } from 'url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-test('idle workers can be recycled', async () => {
-  const pool = new Tinypool({
-    filename: resolve(__dirname, 'fixtures/sleep.js'),
-    minThreads: 4,
-    maxThreads: 4,
-    isolateWorkers: false,
+describe.each(['worker_threads', 'child_process'] as const)('%s', (runtime) => {
+  test('idle workers can be recycled', async () => {
+    const pool = new Tinypool({
+      runtime,
+      filename: resolve(__dirname, 'fixtures/sleep.js'),
+      minThreads: 4,
+      maxThreads: 4,
+      isolateWorkers: false,
+    })
+
+    function getThreadIds() {
+      return pool.threads
+        .map((thread) => thread!.threadId)
+        .sort((a, b) => a - b)
+    }
+
+    expect(pool.threads).toHaveLength(4)
+    const initialThreadIds = getThreadIds()
+
+    await Promise.all(times(4)(() => pool.run({})))
+    expect(getThreadIds()).toStrictEqual(initialThreadIds)
+
+    await pool.recycleWorkers()
+    expect(pool.threads).toHaveLength(4)
+
+    const newThreadIds = getThreadIds()
+    initialThreadIds.forEach((id) => expect(newThreadIds).not.toContain(id))
+
+    await Promise.all(times(4)(() => pool.run({})))
+    initialThreadIds.forEach((id) => expect(newThreadIds).not.toContain(id))
+    expect(getThreadIds()).toStrictEqual(newThreadIds)
   })
 
-  function getThreadIds() {
-    return pool.threads.map((thread) => thread!.threadId).sort((a, b) => a - b)
-  }
+  test('running workers can recycle after task execution finishes', async () => {
+    const pool = new Tinypool({
+      runtime,
+      filename: resolve(__dirname, 'fixtures/sleep.js'),
+      minThreads: 4,
+      maxThreads: 4,
+      isolateWorkers: false,
+    })
 
-  expect(pool.threads).toHaveLength(4)
-  const initialThreadIds = getThreadIds()
+    function getThreadIds() {
+      return pool.threads
+        .map((thread) => thread!.threadId)
+        .sort((a, b) => a - b)
+    }
 
-  await Promise.all(times(4)(() => pool.run({})))
-  expect(getThreadIds()).toStrictEqual(initialThreadIds)
+    expect(pool.threads).toHaveLength(4)
+    const initialThreadIds = getThreadIds()
 
-  await pool.recycleWorkers()
-  expect(pool.threads).toHaveLength(4)
+    const tasks = [
+      ...times(2)(() => pool.run({ time: 1 })),
+      ...times(2)(() => pool.run({ time: 2000 })),
+    ]
 
-  const newThreadIds = getThreadIds()
-  initialThreadIds.forEach((id) => expect(newThreadIds).not.toContain(id))
+    // Wait for first two tasks to finish
+    await Promise.all(tasks.slice(0, 2))
 
-  await Promise.all(times(4)(() => pool.run({})))
-  initialThreadIds.forEach((id) => expect(newThreadIds).not.toContain(id))
-  expect(getThreadIds()).toStrictEqual(newThreadIds)
-})
+    await pool.recycleWorkers()
+    const threadIds = getThreadIds()
 
-test('running workers can recycle after task execution finishes', async () => {
-  const pool = new Tinypool({
-    filename: resolve(__dirname, 'fixtures/sleep.js'),
-    minThreads: 4,
-    maxThreads: 4,
-    isolateWorkers: false,
+    // Idle workers should have been recycled immediately
+    // Running workers should not have recycled yet
+    expect(intersection(threadIds, initialThreadIds)).toHaveLength(2)
+
+    await Promise.all(tasks)
+
+    // All workers should have recycled now
+    const newThreadIds = getThreadIds()
+    initialThreadIds.forEach((id) => expect(newThreadIds).not.toContain(id))
   })
-
-  function getThreadIds() {
-    return pool.threads.map((thread) => thread!.threadId).sort((a, b) => a - b)
-  }
-
-  expect(pool.threads).toHaveLength(4)
-  const initialThreadIds = getThreadIds()
-
-  const tasks = [
-    ...times(2)(() => pool.run({ time: 1 })),
-    ...times(2)(() => pool.run({ time: 2000 })),
-  ]
-
-  // Wait for first two tasks to finish
-  await Promise.all(tasks.slice(0, 2))
-
-  await pool.recycleWorkers()
-  const threadIds = getThreadIds()
-
-  // Idle workers should have been recycled immediately
-  expect(threadIds).not.toContain(initialThreadIds[0])
-  expect(threadIds).not.toContain(initialThreadIds[1])
-
-  // Running workers should not have recycled yet
-  expect(threadIds).toContain(initialThreadIds[2])
-  expect(threadIds).toContain(initialThreadIds[3])
-
-  await Promise.all(tasks)
-
-  // All workers should have recycled now
-  const newThreadIds = getThreadIds()
-  initialThreadIds.forEach((id) => expect(newThreadIds).not.toContain(id))
 })
 
 function times(count: number) {
   return function run<T>(fn: () => T): T[] {
     return Array(count).fill(0).map(fn)
   }
+}
+
+function intersection<T>(a: T[], b: T[]) {
+  return a.filter((value) => b.includes(value))
 }

--- a/test/resource-limits.test.ts
+++ b/test/resource-limits.test.ts
@@ -36,58 +36,62 @@ test('resourceLimits causes task to reject', async () => {
   )
 })
 
-test('worker is recycled after reaching maxMemoryLimitBeforeRecycle', async () => {
-  const pool = new Tinypool({
-    filename: resolve(__dirname, 'fixtures/leak-memory.js'),
-    maxMemoryLimitBeforeRecycle: 10_000_000,
-    isolateWorkers: false,
-    minThreads: 1,
-    maxThreads: 1,
-  })
+describe.each(['worker_threads', 'child_process'] as const)('%s', (runtime) => {
+  test('worker is recycled after reaching maxMemoryLimitBeforeRecycle', async () => {
+    const pool = new Tinypool({
+      filename: resolve(__dirname, 'fixtures/leak-memory.js'),
+      maxMemoryLimitBeforeRecycle: 10_000_000,
+      isolateWorkers: false,
+      minThreads: 1,
+      maxThreads: 1,
+      runtime,
+    })
 
-  const originalWorkerId = pool.threads[0]?.threadId
-  expect(originalWorkerId).toBeGreaterThan(0)
+    const originalWorkerId = pool.threads[0]?.threadId
+    expect(originalWorkerId).toBeGreaterThan(0)
 
-  let finalThreadId = originalWorkerId
-  let rounds = 0
+    let finalThreadId = originalWorkerId
+    let rounds = 0
 
-  // This is just an estimate of how to leak "some" memory - it's not accurate.
-  // Running 100 loops should be enough to make the worker reach memory limit and be recycled.
-  // Use the `rounds` to make sure we don't reach the limit on the first round.
-  for (const _ of Array(100).fill(0)) {
-    await pool.run(10_000)
+    // This is just an estimate of how to leak "some" memory - it's not accurate.
+    // Running 100 loops should be enough to make the worker reach memory limit and be recycled.
+    // Use the `rounds` to make sure we don't reach the limit on the first round.
+    for (const _ of Array(100).fill(0)) {
+      await pool.run(10_000)
 
-    if (pool.threads[0]) {
-      finalThreadId = pool.threads[0].threadId
+      if (pool.threads[0]) {
+        finalThreadId = pool.threads[0].threadId
+      }
+
+      if (finalThreadId !== originalWorkerId) {
+        break
+      }
+
+      rounds++
     }
 
-    if (finalThreadId !== originalWorkerId) {
-      break
-    }
+    // Test setup should not reach max memory on first round
+    expect(rounds).toBeGreaterThan(1)
 
-    rounds++
-  }
-
-  // Test setup should not reach max memory on first round
-  expect(rounds).toBeGreaterThan(1)
-
-  // Thread should have been recycled
-  expect(finalThreadId).not.toBe(originalWorkerId)
-})
-
-test('recycled workers should not crash pool (regression)', async () => {
-  const pool = new Tinypool({
-    filename: resolve(__dirname, 'fixtures/leak-memory.js'),
-    maxMemoryLimitBeforeRecycle: 10,
-    isolateWorkers: false,
-    minThreads: 2,
-    maxThreads: 2,
+    // Thread should have been recycled
+    expect(finalThreadId).not.toBe(originalWorkerId)
   })
 
-  // This should not crash the pool
-  await Promise.all(
-    Array(10)
-      .fill(0)
-      .map(() => pool.run(10_000))
-  )
+  test('recycled workers should not crash pool (regression)', async () => {
+    const pool = new Tinypool({
+      filename: resolve(__dirname, 'fixtures/leak-memory.js'),
+      maxMemoryLimitBeforeRecycle: 10,
+      isolateWorkers: false,
+      minThreads: 2,
+      maxThreads: 2,
+      runtime,
+    })
+
+    // This should not crash the pool
+    await Promise.all(
+      Array(10)
+        .fill(0)
+        .map(() => pool.run(10_000))
+    )
+  })
 })

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,0 +1,181 @@
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { Tinypool } from 'tinypool'
+import EventEmitter from 'events'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+describe('worker_threads', () => {
+  test('runs code in worker_threads', async () => {
+    const pool = createPool({ runtime: 'worker_threads' })
+
+    const result = await pool.run(`
+      (async () => {
+        const workerThreads = await import("worker_threads");
+
+        return {
+          sum: 11 + 12,
+          isMainThread: workerThreads.isMainThread,
+          pid: process.pid,
+        }
+      })()
+    `)
+    expect(result.sum).toBe(23)
+    expect(result.isMainThread).toBe(false)
+    expect(result.pid).toBe(process.pid)
+  })
+
+  test('sets tinypool state', async () => {
+    const pool = createPool({ runtime: 'worker_threads' })
+
+    const result = await pool.run('process.__tinypool_state__')
+    expect(result.isTinypoolWorker).toBe(true)
+    expect(result.isWorkerThread).toBe(true)
+    expect(result.isChildProcess).toBe(undefined)
+  })
+
+  test("worker's threadId is used as threadId", async () => {
+    const pool = createPool({ runtime: 'worker_threads' })
+    const threadId = pool.threads[0]!.threadId
+
+    const result = await pool.run(`
+      (async () => {
+        const workerThreads = await import("worker_threads");
+        return workerThreads.threadId;
+      })()
+    `)
+    expect(result).toBe(threadId)
+  })
+})
+
+describe('child_process', () => {
+  test('runs code in child_process', async () => {
+    const pool = createPool({ runtime: 'child_process' })
+
+    const result = await pool.run(`
+    (async () => {
+      const workerThreads = await import("worker_threads");
+
+      return {
+        sum: 11 + 12,
+        isMainThread: workerThreads.isMainThread,
+        pid: process.pid,
+      }
+    })()
+  `)
+    expect(result.sum).toBe(23)
+    expect(result.isMainThread).toBe(true)
+    expect(result.pid).not.toBe(process.pid)
+  })
+
+  test('sets tinypool state', async () => {
+    const pool = createPool({ runtime: 'child_process' })
+
+    const result = await pool.run('process.__tinypool_state__')
+    expect(result.isTinypoolWorker).toBe(true)
+    expect(result.isChildProcess).toBe(true)
+    expect(result.isWorkerThread).toBe(undefined)
+  })
+
+  test("sub-process's process ID is used as threadId", async () => {
+    const pool = createPool({ runtime: 'child_process' })
+    const threadId = pool.threads[0]!.threadId
+
+    const result = await pool.run('process.pid')
+    expect(result).toBe(threadId)
+  })
+
+  test('errors are serialized', async () => {
+    const pool = createPool({ runtime: 'child_process' })
+
+    const error = await pool
+      .run("throw new TypeError('Test message');")
+      .catch((e) => e)
+
+    expect(error.name).toBe('TypeError')
+    expect(error.message).toBe('Test message')
+    expect(error.stack).toMatch('fixtures/eval.js')
+  })
+
+  test('can send messages to port', async () => {
+    const pool = createPool({
+      runtime: 'child_process',
+      filename: path.resolve(
+        __dirname,
+        'fixtures/child_process-communication.mjs'
+      ),
+    })
+
+    const emitter = new EventEmitter()
+
+    const startup = new Promise<void>((resolve) =>
+      emitter.on(
+        'response',
+        (message) => message === 'Child process started' && resolve()
+      )
+    )
+
+    const runPromise = pool.run('default', {
+      channel: {
+        onMessage: (callback) => emitter.on('message', callback),
+        postMessage: (message) => emitter.emit('response', message),
+      },
+    })
+
+    // Wait for the child process to start
+    await startup
+
+    const response = new Promise<any>((resolve) =>
+      emitter.on(
+        'response',
+        (message) => message !== 'Hello from main' && resolve(message)
+      )
+    )
+
+    // Send message to child process
+    emitter.emit('message', 'Hello from main')
+
+    // Wait for task to finish
+    await runPromise
+
+    // Wait for response from child
+    const result = await response
+
+    expect(result).toMatchObject({
+      received: 'Hello from main',
+      response: 'Hello from worker',
+    })
+  })
+})
+
+test('runtime can be changed after recycle', async () => {
+  const pool = createPool({ runtime: 'worker_threads' })
+  const getState = 'process.__tinypool_state__'
+
+  await expect(
+    Promise.all([pool.run(getState), pool.run(getState)])
+  ).resolves.toMatchObject([{ isWorkerThread: true }, { isWorkerThread: true }])
+
+  await pool.recycleWorkers({ runtime: 'child_process' })
+
+  await expect(
+    Promise.all([pool.run(getState), pool.run(getState)])
+  ).resolves.toMatchObject([{ isChildProcess: true }, { isChildProcess: true }])
+
+  await pool.recycleWorkers({ runtime: 'worker_threads' })
+
+  expect(await pool.run(getState)).toMatchObject({
+    isWorkerThread: true,
+  })
+})
+
+function createPool(options: Partial<Tinypool['options']>) {
+  const pool = new Tinypool({
+    filename: path.resolve(__dirname, 'fixtures/eval.js'),
+    minThreads: 1,
+    maxThreads: 1,
+    ...options,
+  })
+
+  return pool
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entryPoints: ['src/index.ts', 'src/worker.ts'],
+  entryPoints: ['src/index.ts', 'src/entry/*.ts'],
   splitting: true,
   legacyOutput: true,
   outDir: 'dist',


### PR DESCRIPTION
- Closes #64 

&nbsp;

- No semver breaking changes
- Adds new internal common interface `TinypoolWorker`
- Moves existing `node:worker_threads` worker to `runtime/thread-worker.ts` - backwards compatible
- Adds new `runtime` option for pool constructor
- Creates new `TinypoolWorker` which runs on `node:child_process`, `runtime/process-worker.ts`. This is used when `runtime: 'child_process'` pool option is used.
- Adds new `channel` option for `pool.run()` method. This is used to pass callback for **main thread/process <-> worker** communication. This option is not supported by `ThreadWorker`.
- Adds new `runtime` option for `pool.recycleWorkers`. This can be used to recycle current workers and change the runtime of next set of workers.

&nbsp;

- [x] Constructor support: `new TinyPool({ runtime: 'child_process' })`
- [x] Pool methods: `pool.recycleWorkers({ runtime: 'child_process' })`
- [x] Communication via something like `MessagePort` - maybe introduce new `run()` option for this -> `channel` option created
