### PR TITLE
feat: support Bun

### DIFF
--- a/benchmark/fixtures/wrap-add-bun.mjs
+++ b/benchmark/fixtures/wrap-add-bun.mjs
@@ -1,0 +1,5 @@
+import add from './add.mjs'
+
+self.onmessage = (event) => {
+  postMessage(add(event.data))
+}

--- a/benchmark/isolate-benchmark.mjs
+++ b/benchmark/isolate-benchmark.mjs
@@ -1,35 +1,60 @@
 /*
- * Benchmark for testing whether Tinypool's worker creation and teardown is expensive.
+ * Benchmark focusing on the performance `isolateWorkers` option
+ *
+ * Options:
+ * - `--rounds` (optional) - Specify how many iterations to run
+ * - `--threads` (optional) - Specify how many threads to use
  */
-import { cpus } from 'node:os'
-import { Worker } from 'node:worker_threads'
+
+import * as os from 'node:os'
+import * as WorkerThreads from 'node:worker_threads'
 
 import Tinypool from '../dist/esm/index.js'
 
-const THREADS = cpus().length - 1
-const ROUNDS = 5_000
+const IS_BUN = process.versions.bun !== undefined
+const USE_ATOMICS = !IS_BUN
+const THREADS = parseInt(getArgument('--threads') ?? getMaxThreads(), 10)
+const ROUNDS = parseInt(getArgument('--rounds') ?? '5_000', 10)
 
-await logTime('Tinypool', runTinypool)
-await logTime('Worker threads', runWorkerThreads)
+console.log('Options:', { THREADS, ROUNDS, IS_BUN }, '\n')
 
-async function runTinypool() {
+await logTime(
+  "Tinypool { runtime: 'worker_threds' }",
+  runTinypool('worker_threds')
+)
+await logTime(
+  "Tinypool { runtime: 'child_process' }",
+  runTinypool('child_process')
+)
+
+if (IS_BUN) {
+  await logTime('Native Bun workers', runBunWorkers())
+}
+
+await logTime('Native node:worker_threads', runNodeWorkerThreads())
+
+function runTinypool(runtime) {
   const pool = new Tinypool({
+    runtime,
     filename: new URL('./fixtures/add.mjs', import.meta.url).href,
     isolateWorkers: true,
     minThreads: THREADS,
     maxThreads: THREADS,
+    useAtomics: USE_ATOMICS,
   })
 
-  await Promise.all(
-    Array(ROUNDS)
-      .fill()
-      .map(() => pool.run({ a: 1, b: 2 }))
-  )
+  return async function run() {
+    await Promise.all(
+      Array(ROUNDS)
+        .fill()
+        .map(() => pool.run({ a: 1, b: 2 }))
+    )
+  }
 }
 
-async function runWorkerThreads() {
+function runNodeWorkerThreads() {
   async function task() {
-    const worker = new Worker('./fixtures/wrap-add.mjs')
+    const worker = new WorkerThreads.Worker('./fixtures/wrap-add.mjs')
     worker.postMessage({ a: 1, b: 2 })
 
     await new Promise((resolve, reject) =>
@@ -50,16 +75,75 @@ async function runWorkerThreads() {
     }
   }
 
-  await Promise.all(
-    Array(THREADS)
-      .fill(execute)
-      .map((task) => task())
-  )
+  return async function run() {
+    await Promise.all(
+      Array(THREADS)
+        .fill(execute)
+        .map((task) => task())
+    )
+  }
+}
+
+function runBunWorkers() {
+  async function task() {
+    const worker = new Worker('./fixtures/wrap-add-bun.mjs')
+    worker.postMessage({ a: 1, b: 2 })
+
+    await new Promise((resolve, reject) => {
+      worker.onmessage = (event) =>
+        event.data === 3 ? resolve() : reject('Not 3')
+    })
+
+    await worker.terminate()
+  }
+
+  const pool = Array(ROUNDS).fill(task)
+
+  async function execute() {
+    const task = pool.shift()
+
+    if (task) {
+      await task()
+      return execute()
+    }
+  }
+
+  return async function run() {
+    await Promise.all(
+      Array(THREADS)
+        .fill(execute)
+        .map((task) => task())
+    )
+  }
+}
+
+function getArgument(flag) {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return
+
+  return process.argv[index + 1]
+}
+
+function getMaxThreads() {
+  return os.availableParallelism?.() || os.cpus().length - 1
 }
 
 async function logTime(label, method) {
+  console.log(`${label} | START`)
+
   const start = process.hrtime.bigint()
   await method()
   const end = process.hrtime.bigint()
-  console.log(label, 'took', ((end - start) / 1_000_000n).toString(), 'ms')
+
+  console.log(`${label} | END   ${((end - start) / 1_000_000n).toString()} ms`)
+
+  console.log('Cooling down for 2s')
+  const interval = setInterval(() => process.stdout.write('.'), 100)
+  await sleep(2_000)
+  clearInterval(interval)
+  console.log(' ✓\n')
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms))
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -18,7 +18,7 @@ export interface TinypoolWorker {
     resourceLimits?: any
     workerData?: TinypoolData
     trackUnmanagedFds?: boolean
-  }): void
+  }): Promise<void>
   terminate(): Promise<any>
   postMessage(message: any, transferListItem?: TransferListItem[]): void
   setChannel?: (channel: TinypoolChannel) => void
@@ -55,6 +55,10 @@ export interface RequestMessage {
   task: any
   filename: string
   name: string
+}
+
+export interface SpawnMessage {
+  spawned: true
 }
 
 export interface ReadyMessage {

--- a/src/entry/process.ts
+++ b/src/entry/process.ts
@@ -3,6 +3,7 @@ import {
   ReadyMessage,
   RequestMessage,
   ResponseMessage,
+  SpawnMessage,
   StartupMessage,
   TinypoolWorkerMessage,
 } from '../common'
@@ -21,6 +22,12 @@ process.__tinypool_state__ = {
   isTinypoolWorker: true,
   workerData: null,
   workerId: process.pid,
+}
+
+let emittedReady = false
+if (!emittedReady) {
+  process.send!(<SpawnMessage>{ spawned: true })
+  emittedReady = true
 }
 
 process.on('message', (message: IncomingMessage) => {

--- a/src/entry/worker.ts
+++ b/src/entry/worker.ts
@@ -38,6 +38,12 @@ parentPort!.on('message', (message: StartupMessage) => {
   useAtomics =
     process.env.PISCINA_DISABLE_ATOMICS === '1' ? false : message.useAtomics
 
+  if (useAtomics && process.versions.bun) {
+    const error = 'useAtomics cannot be used with Bun at the moment.'
+    console.error(error)
+    throw new Error(error)
+  }
+
   const { port, sharedBuffer, filename, name } = message
 
   ;(async function () {
@@ -48,6 +54,7 @@ parentPort!.on('message', (message: StartupMessage) => {
     const readyMessage: ReadyMessage = { ready: true }
     parentPort!.postMessage(readyMessage)
 
+    port.start()
     port.on('message', onMessage.bind(null, port, sharedBuffer))
     atomicsWaitLoop(port, sharedBuffer)
   })().catch(throwInNextTick)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
+export default defineConfig((mode) => ({
   entryPoints: ['src/index.ts', 'src/entry/*.ts'],
   splitting: true,
   legacyOutput: true,
@@ -9,5 +9,5 @@ export default defineConfig({
   tsconfig: './tsconfig.json',
   target: 'es2020',
   clean: true,
-  dts: true,
-})
+  dts: mode.watch ? false : true,
+}))


### PR DESCRIPTION
Related to https://github.com/vitest-dev/vitest/pull/4111

- `node:worker_threads` are unstable on Bun and crash under heavy load
- `node:worker_threads` get stuck on Bun if there are `while(true) {}` loops inside the worker
- Bun's `Worker`s are unstable, leak memory and crash under heavy load
- Bun does not open `MessagePort`s automatically, `port.start()` must be called manually
- Bun does not start `node:child_process` immediately like NodeJS does. It also does not emit `spawn` event. Manual work-arounds are required.

```sh
# Test how fast NodeJS can spin up and tear down 5000 worker_threads, 8 at a time on 8-CPU machine
$ node isolate-benchmark.mjs --threads 7 --rounds 5000
Options: { THREADS: 7, ROUNDS: 5000, IS_BUN: false } 

Native node:worker_threads | START
Native node:worker_threads | END   24622 ms

# Test how fast Bun can spin up and tear down 5000 Workers, 8 at a time on 8-CPU machine
$ bun isolate-benchmark.mjs --threads 7 --rounds 5000
Options: {
  THREADS: 7,
  ROUNDS: 5000,
  IS_BUN: true
} 

Native Bun workers | START
FATAL ERROR: JavaScript garbage collection failed because thread_get_state returned an error (268435459). This is probably the result of running inside Rosetta, which is not supported.
/Users/jarred/actions-runner/_work/WebKit/WebKit/Source/WTF/wtf/posix/ThreadingPOSIX.cpp(497) : size_t WTF::Thread::getRegisters(const WTF::ThreadSuspendLocker &, WTF::PlatformRegisters &)
```

Sometimes Bun crashes with `libc++abi: Pure virtual function called! Abort trap: 6` error. 
