### PR TITLE
fix: `recycleWorkers` to destroy idle workers when `runtime` changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1071,12 +1071,16 @@ class ThreadPool {
   }
 
   async recycleWorkers(options: Pick<Options, 'runtime'> = {}) {
+    const runtimeChanged =
+      options?.runtime && options.runtime !== this.options.runtime
+
     if (options?.runtime) {
       this.options.runtime = options.runtime
     }
 
-    // Worker's are automatically recycled when isolateWorkers is enabled
-    if (this.options.isolateWorkers) {
+    // Worker's are automatically recycled when isolateWorkers is enabled.
+    // Idle workers still need to be recycled if runtime changed
+    if (this.options.isolateWorkers && !runtimeChanged) {
       return
     }
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -169,6 +169,26 @@ test('runtime can be changed after recycle', async () => {
   })
 })
 
+test('isolated idle workers change runtime after recycle', async () => {
+  const pool = createPool({
+    runtime: 'worker_threads',
+    minThreads: 2,
+    maxThreads: 2,
+    isolateWorkers: true,
+  })
+  const getState = 'process.__tinypool_state__'
+
+  await expect(pool.run(getState)).resolves.toMatchObject({
+    isWorkerThread: true,
+  })
+
+  await pool.recycleWorkers({ runtime: 'child_process' })
+
+  await expect(
+    Promise.all([pool.run(getState), pool.run(getState)])
+  ).resolves.toMatchObject([{ isChildProcess: true }, { isChildProcess: true }])
+})
+
 function createPool(options: Partial<Tinypool['options']>) {
   const pool = new Tinypool({
     filename: path.resolve(__dirname, 'fixtures/eval.js'),


### PR DESCRIPTION
Idle workers are not recycled when `runtime` changes and `isolateWorkers: true` option is used.

https://github.com/tinylibs/tinypool/blob/999778ed8acccf18303760558f807f0e208c8b3b/src/index.ts#L1074-L1081

This bug was introduced in https://github.com/tinylibs/tinypool/pull/65/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1073 where `runtime` changing during `recycleWorkers` was introduced. 