### PR TITLE
fix: pass argv to child_process

### DIFF
--- a/src/runtime/process-worker.ts
+++ b/src/runtime/process-worker.ts
@@ -22,6 +22,7 @@ export default class ProcessWorker implements TinypoolWorker {
   initialize(options: Parameters<TinypoolWorker['initialize']>[0]) {
     this.process = fork(
       fileURLToPath(import.meta.url + '/../entry/process.js'),
+      options.argv,
       options
     )
     this.threadId = this.process.pid!

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -96,6 +96,17 @@ test('passing argv to workers works', async () => {
   expect(env).toEqual(['a', 'b', 'c'])
 })
 
+test('passing argv to child process', async () => {
+  const pool = new Tinypool({
+    runtime: 'child_process',
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    argv: ['a', 'b', 'c'],
+  })
+
+  const env = await pool.run('process.argv.slice(2)')
+  expect(env).toEqual(['a', 'b', 'c'])
+})
+
 test('passing execArgv to workers works', async () => {
   const pool = new Tinypool({
     filename: resolve(__dirname, 'fixtures/eval.js'),


### PR DESCRIPTION
Fixed: https://github.com/tinylibs/tinypool/issues/78

add pass argv
https://github.com/nodejs/node/blob/main/lib/child_process.js#L158
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/child_process.d.ts#L1391

add to parameters `options.argv`
```js
this.process = fork(
      fileURLToPath(import.meta.url + '/../entry/process.js'),
      options.argv,
      options
    )
```

- [X] - add test