### PR TITLE
fix: set correct `workerId` in `runtime: 'child_process'`

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -16,7 +16,7 @@ export interface TinypoolWorker {
     argv?: string[]
     execArgv?: string[]
     resourceLimits?: any
-    workerData?: TinypoolData
+    workerData: TinypoolData
     trackUnmanagedFds?: boolean
   }): void
   terminate(): Promise<any>

--- a/src/entry/process.ts
+++ b/src/entry/process.ts
@@ -20,7 +20,7 @@ process.__tinypool_state__ = {
   isChildProcess: true,
   isTinypoolWorker: true,
   workerData: null,
-  workerId: process.pid,
+  workerId: Number(process.env.TINYPOOL_WORKER_ID),
 }
 
 process.on('message', (message: IncomingMessage) => {

--- a/src/runtime/process-worker.ts
+++ b/src/runtime/process-worker.ts
@@ -23,7 +23,13 @@ export default class ProcessWorker implements TinypoolWorker {
     this.process = fork(
       fileURLToPath(import.meta.url + '/../entry/process.js'),
       options.argv,
-      options
+      {
+        ...options,
+        env: {
+          ...options.env,
+          TINYPOOL_WORKER_ID: options.workerData[0].workerId.toString(),
+        },
+      }
     )
     this.threadId = this.process.pid!
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -85,6 +85,12 @@ describe('child_process', () => {
     expect(result).toBe(threadId)
   })
 
+  test('child process workerId should be internal tinypool workerId', async () => {
+    const pool = createPool({ runtime: 'child_process' })
+    const workerId = await pool.run('process.__tinypool_state__.workerId')
+    expect(workerId).toBe(1)
+  })
+
   test('errors are serialized', async () => {
     const pool = createPool({ runtime: 'child_process' })
 


### PR DESCRIPTION
First attempt at using the correct `threadId`/`workerId` for the worker when in `child_process` mode.

- Set worker data as required in init options as it seems to be always defined.
- Pass internal (correct) tinypool workerId down to fork with `process.env`
- Set correct fork state `process.__tinypool_state__.workerId` from the env variable