### PR TITLE
fix: `pool.destroy` to clean up async resources

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1161,8 +1161,9 @@ class Tinypool extends EventEmitterAsyncResource {
     })
   }
 
-  destroy() {
-    return this.#pool.destroy()
+  async destroy() {
+    await this.#pool.destroy()
+    this.emitDestroy()
   }
 
   get options(): FilledOptions {


### PR DESCRIPTION
This issue came up while looking into https://github.com/vitest-dev/vitest/pull/5544.

Tinypool's async resources show up in [Vitest's `hanging-process` reporter](https://vitest.dev/guide/reporters.html#hanging-process-reporter).

https://github.com/tinylibs/tinypool/blob/f86e82927371b54ba26577d818b86393ccf902c2/src/EventEmitterAsyncResource.ts#L24

```
 RUN  v1.5.0 /Users/x/vitest/test/cli/fixtures/project

 ✓ |space_1| base.test.ts  (1 test) 2ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  21:40:23
   Duration  197ms (transform 17ms, setup 0ms, collect 12ms, tests 2ms, environment 0ms, prepare 66ms)

There are 12 handle(s) keeping the process running

# Tinypool
node:internal/async_hooks:202                                                                             
node:internal/async_hooks:505                                                                             
file:///Users/x/vitest/node_modules/.pnpm/tinypool@0.8.3/node_modules/tinypool/dist/esm/index.js:37 
file:///Users/x/vitest/node_modules/.pnpm/tinypool@0.8.3/node_modules/tinypool/dist/esm/index.js:58 
file:///Users/x/vitest/node_modules/.pnpm/tinypool@0.8.3/node_modules/tinypool/dist/esm/index.js:945
file:///Users/x/vitest/packages/vitest/dist/vendor/cac.dwzv-pfu.js:8776                             
file:///Users/x/vitest/packages/vitest/dist/vendor/cac.dwzv-pfu.js:9425                             
file:///Users/x/vitest/packages/vitest/dist/vendor/cac.dwzv-pfu.js:9450                             

# FILEHANDLE
node:internal/async_hooks:202

... more FILEHANDLES here

# FILEHANDLE
node:internal/async_hooks:202
close timed out after 10000ms
Tests closed successfully but something prevents 2 Vite servers from exiting
You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters
```

After this changes the resource is cleaned up during `pool.destroy()` and it doesn't show up in reports anymore:

```
 RUN  v1.5.0 /Users/x/vitest/test/cli/fixtures/project

 ✓ |space_1| base.test.ts  (1 test) 1ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  21:41:19
   Duration  188ms (transform 12ms, setup 0ms, collect 8ms, tests 1ms, environment 0ms, prepare 53ms)

There are 11 handle(s) keeping the process running

# FILEHANDLE
node:internal/async_hooks:202

... more FILEHANDLES here

# FILEHANDLE
node:internal/async_hooks:202
close timed out after 10000ms
Tests closed successfully but something prevents 2 Vite servers from exiting
You can try to identify the cause by enabling "hanging-process" reporter. See https://vitest.dev/config/#reporters
```
