### PR TITLE
chore: add "./package.json" to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Add `./package.json` to `exports` for package locating.

When bundling a node library, one may need to copy the `dist/entry` directory into output directory (because it is not directly referenced). It is useful to have a `package.json` export when one uses build script like this:

```ts
require.resolve('tinypool/package.json')
```

It is also common practice for popular packages such as vite.

https://github.com/vitejs/vite/blob/1025bb6d8f21c0cb9fe72405d42e0f91bb3f1d8e/packages/vite/package.json#L43