### PR TITLE
Expose cpuCount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ declare global {
   }
 }
 
-const cpuCount: number = physicalCpuCount
+export const cpuCount: number = physicalCpuCount
 
 interface AbortSignalEventTargetAddOptions {
   once: boolean


### PR DESCRIPTION
This lib computes physical CPUs for pool default values, but this computed value is not exposed.

Exposing it gives the possibility for the user to create more advanced algorithms to define the appropriate number of threads.

I'm not sure what name to use for the export, just wanted to open the discussion that I'd like to access that value.