### PR TITLE
feat: add `teardown` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ We have a similar API to Piscina, so for more information, you can read Piscina'
 - `runtime`: Used to pick worker runtime. Default value is `worker_threads`.
   - `worker_threads`: Runs workers in [`node:worker_threads`](https://nodejs.org/api/worker_threads.html). For `main thread <-> worker thread` communication you can use [`MessagePort`](https://nodejs.org/api/worker_threads.html#class-messageport) in the `pool.run()` method's [`transferList` option](https://nodejs.org/api/worker_threads.html#portpostmessagevalue-transferlist). See [example](#main-thread---worker-thread-communication).
   - `child_process`: Runs workers in [`node:child_process`](https://nodejs.org/api/child_process.html). For `main thread <-> worker process` communication you can use `TinypoolChannel` in the `pool.run()` method's `channel` option. For filtering out the Tinypool's internal messages see `TinypoolWorkerMessage`. See [example](#main-process---worker-process-communication).
+- `teardown`: name of the function in file that should be called before worker is terminated. Must be named exported.
 
 #### Pool methods
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "test": "vitest",
     "bench": "vitest bench",
-    "dev": "tsdown --watch",
+    "dev": "tsdown --watch ./src",
     "build": "tsdown",
     "publish": "clean-publish",
     "lint": "eslint --max-warnings=0",

--- a/test/fixtures/teardown.mjs
+++ b/test/fixtures/teardown.mjs
@@ -1,0 +1,19 @@
+import { setTimeout } from 'node:timers/promises'
+
+let state = 0
+
+/** @type {import("node:worker_threads").MessagePort } */
+let port
+
+export default function task(options) {
+  port ||= options?.port
+  state++
+
+  return `Output of task #${state}`
+}
+
+export async function namedTeardown() {
+  await setTimeout(50)
+
+  port?.postMessage(`Teardown of task #${state}`)
+}

--- a/test/teardown.test.ts
+++ b/test/teardown.test.ts
@@ -1,0 +1,59 @@
+import { dirname, resolve } from 'node:path'
+import { Tinypool } from 'tinypool'
+import { fileURLToPath } from 'node:url'
+import { MessageChannel } from 'node:worker_threads'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('isolated workers call teardown on worker recycle', async () => {
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/teardown.mjs'),
+    minThreads: 1,
+    maxThreads: 1,
+    isolateWorkers: true,
+    teardown: 'namedTeardown',
+  })
+
+  for (const _ of [1, 2, 3, 4, 5]) {
+    const { port1, port2 } = new MessageChannel()
+    const promise = new Promise((resolve) => port2.on('message', resolve))
+
+    const output = await pool.run({ port: port1 }, { transferList: [port1] })
+    expect(output).toBe('Output of task #1')
+
+    await expect(promise).resolves.toBe('Teardown of task #1')
+  }
+})
+
+test('non-isolated workers call teardown on worker recycle', async () => {
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/teardown.mjs'),
+    minThreads: 1,
+    maxThreads: 1,
+    isolateWorkers: false,
+    teardown: 'namedTeardown',
+  })
+
+  function unexpectedTeardown(message: string) {
+    assert.fail(
+      `Teardown should not have been called yet. Received "${message}"`
+    )
+  }
+
+  const { port1, port2 } = new MessageChannel()
+
+  for (const index of [1, 2, 3, 4, 5]) {
+    port2.on('message', unexpectedTeardown)
+
+    const transferList = index === 1 ? [port1] : []
+
+    const output = await pool.run({ port: transferList[0] }, { transferList })
+    expect(output).toBe(`Output of task #${index}`)
+  }
+
+  port2.off('message', unexpectedTeardown)
+  const promise = new Promise((resolve) => port2.on('message', resolve))
+
+  await pool.destroy()
+  await expect(promise).resolves.toMatchInlineSnapshot(`"Teardown of task #5"`)
+})


### PR DESCRIPTION
- Adds support for providing teardown function that is called before worker is terminated.
- Closes https://github.com/tinylibs/tinypool/issues/113

```ts
const pool = new Tinypool({ filename: './math.js', teardown: 'namedTeardown' })
                                                          // ^^^^^^^^^^^^^^^ Name of the function, can be anything

const result = await pool.run({ a: 2, b: 3 }, { name: 'sum'  });

assert(result === 5);
```

```ts
// math.ts
export function sum(a, b) {
  return a + b;
}

export async function namedTeardown() {
  await Promise.resolve(); // cleanup here
}
```
