### PR TITLE
fix: add preferUnplugged to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
     "typescript-eslint": "^7.13.0",
     "vite": "^5.2.11",
     "vitest": "^4.0.1"
-  }
+  },
+  "preferUnplugged": true
 }


### PR DESCRIPTION
## Problem

Right now, the default behaviour of tinypool with child process runtime will always break in yarn PnP environment. End-user can either mark this package as unplugged to let fork resolves process.js correctly with builtin node module resolution or pass `NODE_OPTIONS` to Tinypool constructor options (and by extension, to `child_process.fork()`) to allow it to resolve process.js with yarn PnP resolution.

## Reproduction

https://github.com/slainless/tinypool-reproduction

To fix the reproduction, just run `yarn unplug tinypool`.

To test `preferUnplugged` on distribution:
1. Add the flag to local tinypool repository
2. Build & pack
3. `yarn link` to local tinypool from repro repository then change protocol from `portal:` to `file:`
4. `yarn install`
5. It should install as unplugged by default

## Solution

The most unobstrusive fix is to mark tinypool as [`preferUnplugged`](https://yarnpkg.com/configuration/manifest#preferUnplugged). This should fix the default child process runtime behaviour in yarn PnP environment and release end-user from responsibility of passing NODE_OPTIONS or marking it as unplugged per project basis.

The actual motivation for this PR is actually to unblock oxc integration (which uses tinypool):
- https://github.com/yarnpkg/berry/pull/7078