### PR TITLE
fix(process-worker): handle ERR_IPC_CHANNEL_CLOSED during termination on Node.js 24

### DIFF
--- a/src/runtime/process-worker.ts
+++ b/src/runtime/process-worker.ts
@@ -83,7 +83,7 @@ export default class ProcessWorker implements TinypoolWorker {
   }
 
   private send(message: Parameters<NonNullable<(typeof process)['send']>>[0]) {
-    if (!this.isTerminating) {
+    if (!this.isTerminating && this.process.connected) {
       this.process.send(message)
     }
   }
@@ -116,8 +116,16 @@ export default class ProcessWorker implements TinypoolWorker {
 
   on(event: string, callback: (...args: any[]) => void) {
     return this.process.on(event, (data: TinypoolWorkerMessage) => {
-      // All errors should be forwarded to the pool
+      // All errors should be forwarded to the pool, except IPC channel closure
+      // errors that occur during graceful termination (observed on Node.js 24+
+      // when forceExit causes the IPC channel to close before send() drains).
       if (event === 'error') {
+        if (
+          this.isTerminating &&
+          (data as any)?.code === 'ERR_IPC_CHANNEL_CLOSED'
+        ) {
+          return
+        }
         return callback(data)
       }
 


### PR DESCRIPTION
## Summary

On Node.js 24, the IPC channel between parent and child process closes more aggressively during teardown (e.g. with `forceExit: true` in Vitest). This causes `ERR_IPC_CHANNEL_CLOSED` errors when tinypool tries to send messages to already-disconnected workers, surfacing as unhandled errors even when all tasks completed successfully.

**Root cause:** Two code paths in `ProcessWorker`:

1. `send()` calls `this.process.send(message)` without checking `process.connected`. If the IPC channel closed (but `isTerminating` hasn't been set yet), this throws `ERR_IPC_CHANNEL_CLOSED`.

2. The `on('error')` handler forwards all process errors to the pool's callback. When the IPC channel closes during `terminate()`, Node.js emits `ERR_IPC_CHANNEL_CLOSED` as an 'error' event — forwarding this to the pool causes an unhandled error.

## Changes

- In `send()`: guard with `this.process.connected` so messages are skipped when the IPC channel has already disconnected
- In `on('error')`: suppress `ERR_IPC_CHANNEL_CLOSED` errors when `isTerminating` is true, since these are expected during graceful shutdown

Fixes #130