### PR TITLE
feat: add allowWorkerIdleExit option to suppress idle-worker error events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,18 @@ interface Options {
   isolateWorkers?: boolean
   teardown?: string
   serialization?: SerializationType
+  /**
+   * When `true`, the pool does not surface an `error` event for a worker
+   * that exits while it has no in-flight task. This is useful for pools
+   * that already track worker health via their own channel (e.g. cloud
+   * workerd subprocesses that may segfault during teardown — see
+   * https://github.com/cloudflare/workerd/issues/6763) and do not want
+   * a post-task uncaught exception to fail the whole pool run.
+   *
+   * Defaults to `false` to preserve the historic behavior of surfacing
+   * post-task uncaught exceptions via the pool's `error` event.
+   */
+  allowWorkerIdleExit?: boolean
 }
 
 interface FilledOptions extends Options {
@@ -168,6 +180,7 @@ interface FilledOptions extends Options {
   concurrentTasksPerWorker: number
   useAtomics: boolean
   taskQueue: TaskQueue
+  allowWorkerIdleExit: boolean
 }
 
 const kDefaultOptions: FilledOptions = {
@@ -182,6 +195,7 @@ const kDefaultOptions: FilledOptions = {
   useAtomics: true,
   taskQueue: new ArrayTaskQueue(),
   trackUnmanagedFds: true,
+  allowWorkerIdleExit: false,
 }
 
 interface RunOptions {
@@ -837,7 +851,14 @@ class ThreadPool {
         for (const taskInfo of taskInfos) {
           taskInfo.done(err, null)
         }
-      } else {
+      } else if (!this.options.allowWorkerIdleExit) {
+        // Worker exited while idle (no in-flight task). By default this is
+        // surfaced as a pool-level `error` event so post-task uncaught
+        // exceptions aren't silently swallowed. Pools that track worker
+        // health via their own channel (e.g. cloudflare/vitest-pool-workers
+        // running workerd, which can segfault on shutdown — see
+        // https://github.com/cloudflare/workerd/issues/6763) can opt out
+        // via `allowWorkerIdleExit: true`.
         this.publicInterface.emit('error', err)
       }
     })

--- a/test/allow-worker-idle-exit.test.ts
+++ b/test/allow-worker-idle-exit.test.ts
@@ -1,0 +1,58 @@
+import { dirname, resolve } from 'node:path'
+import { Tinypool } from 'tinypool'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+test('uncaught exception after task yields error event (default)', async () => {
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    maxThreads: 1,
+    useAtomics: false,
+  })
+
+  let errorEmitted: Error | undefined
+  pool.on('error', (err) => {
+    errorEmitted = err as Error
+  })
+
+  const taskResult = pool.run(`
+    setTimeout(() => { throw new Error("not_caught") }, 200);
+    42
+  `)
+  expect(await taskResult).toBe(42)
+
+  // Wait long enough for the async throw + worker exit to propagate.
+  await new Promise((r) => setTimeout(r, 600))
+
+  expect(errorEmitted?.message).toEqual('not_caught')
+
+  await pool.destroy()
+})
+
+test('uncaught exception after task does NOT yield error event when allowWorkerIdleExit is true', async () => {
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    maxThreads: 1,
+    useAtomics: false,
+    allowWorkerIdleExit: true,
+  })
+
+  const errors: unknown[] = []
+  pool.on('error', (err) => {
+    errors.push(err)
+  })
+
+  const taskResult = pool.run(`
+    setTimeout(() => { throw new Error("ignored_when_idle") }, 200);
+    42
+  `)
+  expect(await taskResult).toBe(42)
+
+  // Wait long enough for the async throw + worker exit to propagate.
+  await new Promise((r) => setTimeout(r, 600))
+
+  expect(errors).toEqual([])
+
+  await pool.destroy()
+})


### PR DESCRIPTION
## What

Tinypool currently emits an `error` event on the public interface whenever a worker exits while it has **no in-flight task**. The intent is to surface post-task uncaught exceptions (e.g. an async `setTimeout(() => { throw ... }, 0)` that lands after `pool.run()` has returned), and that behavior is locked in by `test/uncaught-exception-from-handler.test.ts`.

The same code path also fires for workers that die from external causes that the consuming pool already has visibility into — most concretely, **workerd subprocesses that segfault during teardown** (see [cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763), also discussed in this comment thread on the upstream workerd issue tracker). When the workerd child dies after a vitest test file has reported its results, `cloudflare/vitest-pool-workers` is unable to suppress the resulting `Worker exited unexpectedly` event, and the whole vitest run exits with code 1 even though every test body was already reported as passing.

This PR adds an opt-in `allowWorkerIdleExit: boolean` option (default `false`) that lets consuming pools opt out of the public `error` emission for the idle-worker case. Workers that exit mid-task still surface the error to the in-flight task's callback, so genuine task failures continue to fail the affected task.

## How

- `Options.allowWorkerIdleExit?: boolean` (default `false`)
- `FilledOptions.allowWorkerIdleExit: boolean` (the runtime-resolved value)
- `kDefaultOptions.allowWorkerIdleExit = false` (preserves current behavior)
- The existing worker `'error'` handler is now a 3-branch conditional:
  - task in flight → reject the task's callback (unchanged)
  - task not in flight, opt-out enabled → silent (no `error` event)
  - task not in flight, opt-out disabled → emit `error` event (unchanged)

## Tests

- New `test/allow-worker-idle-exit.test.ts` runs the same fixture twice — once with the option unset (asserting the existing error event) and once with `allowWorkerIdleExit: true` (asserting the error event is suppressed).
- The existing `test/uncaught-exception-from-handler.test.ts` continues to lock in the default behavior.

## Cross-references

- [cloudflare/workerd#6763](https://github.com/cloudflare/workerd/issues/6763) — upstream workerd SIGSEGV
- cloudflare/vitest-pool-workers PR #14793 — companion change that handles the same scenario at the pool layer for the bundled 0.16.x version.

## Why not just patch vitest-pool-workers?

That pool does include a mitigation (PR #14793), but it has to live in their vendored copy of tinypool (`dist/worker/lib/tinypool.mjs`) until/unless this option exists upstream. Surfacing it here lets the fix land once and apply to every pool that wants to suppress idle-worker noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>