### PR TITLE
fix: accept process.env in worker options

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -16,7 +16,7 @@ export interface TinypoolChannel {
 export interface TinypoolWorker {
   runtime: string
   initialize(options: {
-    env?: Record<string, string>
+    env?: NodeJS.ProcessEnv
     argv?: string[]
     execArgv?: string[]
     resourceLimits?: any

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ interface Options {
   maxMemoryLimitBeforeRecycle?: number
   argv?: string[]
   execArgv?: string[]
-  env?: Record<string, string>
+  env?: NodeJS.ProcessEnv
   workerData?: any
   taskQueue?: TaskQueue
   trackUnmanagedFds?: boolean

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -86,6 +86,16 @@ test('passing env to workers works', async () => {
   expect(env).toEqual({ A: 'foo' })
 })
 
+test('passing process.env to workers works', async () => {
+  const pool = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+    env: process.env,
+  })
+
+  const env = await pool.run('({...process.env})')
+  expect(env).toEqual(process.env)
+})
+
 test('passing argv to workers works', async () => {
   const pool = new Tinypool({
     filename: resolve(__dirname, 'fixtures/eval.js'),


### PR DESCRIPTION
Closes #136

## Summary

- widen the public `env` option from `Record<string, string>` to `NodeJS.ProcessEnv`
- keep the internal worker interface aligned with the public option type
- add a regression test that passes `process.env` directly to a worker

This deliberately does not add `SHARE_ENV` support because Tinypool also supports the `child_process` runtime, where that worker-thread-only symbol is not accepted.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run test/simple.test.ts` (26 passed)
- `pnpm exec vitest run test/termination.test.ts` (3 passed)

The full test command was also attempted on Windows with Node 24. It reached 87 passing tests before a Vitest child process hit a heap OOM and one termination test timed out; that termination file passed when rerun in isolation.