### PR TITLE
fix: accept process.env and SHARE_ENV in options.env

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,8 @@
-import type { MessagePort, TransferListItem } from 'node:worker_threads'
+import type {
+  MessagePort,
+  TransferListItem,
+  SHARE_ENV,
+} from 'node:worker_threads'
 import type { SerializationType } from 'node:child_process'
 
 /** Channel for communicating between main thread and workers */
@@ -16,7 +20,9 @@ export interface TinypoolChannel {
 export interface TinypoolWorker {
   runtime: string
   initialize(options: {
-    env?: Record<string, string>
+    // Mirrors `WorkerOptions['env']`: `ThreadWorker` hands this straight to
+    // `new Worker`, so it must admit `process.env` and `SHARE_ENV`.
+    env?: NodeJS.Dict<string> | typeof SHARE_ENV
     argv?: string[]
     execArgv?: string[]
     resourceLimits?: any

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {
   MessageChannel,
   type MessagePort,
   receiveMessageOnPort,
+  SHARE_ENV,
 } from 'node:worker_threads'
 import type { SerializationType } from 'node:child_process'
 import { once, EventEmitterAsyncResource } from 'node:events'
@@ -149,7 +150,16 @@ interface Options {
   maxMemoryLimitBeforeRecycle?: number
   argv?: string[]
   execArgv?: string[]
-  env?: Record<string, string>
+  /**
+   * Passed through to the worker. Mirrors `WorkerOptions['env']` from
+   * `node:worker_threads`, so `process.env` and `SHARE_ENV` are both accepted;
+   * the previous `Record<string, string>` rejected `process.env`, whose values
+   * are `string | undefined`.
+   *
+   * `SHARE_ENV` is only meaningful under `runtime: 'worker_threads'` — see
+   * `assertEnvRuntime`.
+   */
+  env?: NodeJS.Dict<string> | typeof SHARE_ENV
   workerData?: any
   taskQueue?: TaskQueue
   trackUnmanagedFds?: boolean
@@ -183,6 +193,30 @@ const kDefaultOptions: FilledOptions = {
   useAtomics: true,
   taskQueue: new ArrayTaskQueue(),
   trackUnmanagedFds: true,
+}
+
+/**
+ * `SHARE_ENV` asks the parent and the worker to share one `process.env`, which
+ * only `worker_threads` can do. `ProcessWorker` builds the child's environment
+ * with `{ ...options.env }`, and spreading a symbol yields `{}` — so a
+ * `child_process` pool given `SHARE_ENV` would silently start its children with
+ * no environment at all beyond `TINYPOOL_WORKER_ID`: no `PATH`, no `HOME`.
+ *
+ * Refusing it is the point of widening the type rather than only widening it:
+ * the value is now expressible, so the combination it cannot honour has to say
+ * so instead of quietly emptying the environment.
+ */
+function assertEnvRuntime(
+  env: Options['env'],
+  runtime: Options['runtime']
+): void {
+  if (env === SHARE_ENV && runtime === 'child_process') {
+    throw new TypeError(
+      "options.env cannot be SHARE_ENV when options.runtime is 'child_process' — " +
+        'sharing an environment requires worker_threads. Pass an explicit ' +
+        'object (for example { ...process.env }) instead.'
+    )
+  }
 }
 
 interface RunOptions {
@@ -1111,6 +1145,12 @@ class ThreadPool {
 
   async recycleWorkers(_options: Pick<Options, 'runtime'> = {}) {
     const options = withNullPrototype(_options)
+
+    // Checked here as well as in the constructor: this is the one path that can
+    // move a pool onto `child_process` after it was built, so a constructor-only
+    // guard would be bypassed by recycling into the runtime that cannot share.
+    assertEnvRuntime(this.options.env, options?.runtime)
+
     const runtimeChanged =
       options?.runtime && options.runtime !== this.options.runtime
 
@@ -1152,6 +1192,8 @@ class Tinypool extends EventEmitterAsyncResource {
 
   constructor(_options: Options = {}) {
     const options = withNullPrototype(_options)
+
+    assertEnvRuntime(options.env, options.runtime)
 
     // convert fractional option values to int
     if (

--- a/src/runtime/process-worker.ts
+++ b/src/runtime/process-worker.ts
@@ -21,6 +21,17 @@ export default class ProcessWorker implements TinypoolWorker {
   isTerminating = false
 
   initialize(options: Parameters<TinypoolWorker['initialize']>[0]) {
+    // `SHARE_ENV` is a symbol, and `{ ...symbol }` is `{}` — a child forked
+    // that way would start with no environment beyond the worker id. Tinypool
+    // refuses the combination up front (`assertEnvRuntime`), so reaching here
+    // with one is a bug rather than user input; it throws rather than falls
+    // back so it cannot become the silent empty environment again.
+    if (typeof options.env === 'symbol') {
+      throw new TypeError(
+        "ProcessWorker cannot share an environment: options.env must be an object for runtime 'child_process'"
+      )
+    }
+
     this.process = fork(
       fileURLToPath(import.meta.url + '/../entry/process.js'),
       options.argv,

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,144 @@
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { SHARE_ENV } from 'node:worker_threads'
+import { Tinypool } from 'tinypool'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const filename = path.resolve(__dirname, 'fixtures/eval.js')
+
+const readEnv = (name: string) => `process.env[${JSON.stringify(name)}]`
+
+describe('options.env', () => {
+  test('accepts a plain object and passes it to worker_threads', async () => {
+    const pool = new Tinypool({
+      filename,
+      runtime: 'worker_threads',
+      minThreads: 1,
+      maxThreads: 1,
+      env: { TINYPOOL_TEST_PLAIN: 'plain' },
+    })
+
+    expect(await pool.run(readEnv('TINYPOOL_TEST_PLAIN'))).toBe('plain')
+    await pool.destroy()
+  })
+
+  test('accepts a plain object and passes it to child_process', async () => {
+    const pool = new Tinypool({
+      filename,
+      runtime: 'child_process',
+      minThreads: 1,
+      maxThreads: 1,
+      env: { TINYPOOL_TEST_PLAIN: 'plain' },
+    })
+
+    expect(await pool.run(readEnv('TINYPOOL_TEST_PLAIN'))).toBe('plain')
+    await pool.destroy()
+  })
+
+  // The type was `Record<string, string>`, and `process.env` is
+  // `Record<string, string | undefined>` — so the documented default of
+  // `new Worker(..., { env })` could not be written down (issue #136).
+  test('accepts process.env, whose values are string | undefined', async () => {
+    process.env.TINYPOOL_TEST_FROM_PROCESS_ENV = 'from-process-env'
+    try {
+      const pool = new Tinypool({
+        filename,
+        runtime: 'worker_threads',
+        minThreads: 1,
+        maxThreads: 1,
+        env: process.env,
+      })
+
+      expect(await pool.run(readEnv('TINYPOOL_TEST_FROM_PROCESS_ENV'))).toBe(
+        'from-process-env'
+      )
+      await pool.destroy()
+    } finally {
+      delete process.env.TINYPOOL_TEST_FROM_PROCESS_ENV
+    }
+  })
+
+  test('accepts SHARE_ENV and actually shares the environment', async () => {
+    const pool = new Tinypool({
+      filename,
+      runtime: 'worker_threads',
+      minThreads: 1,
+      maxThreads: 1,
+      env: SHARE_ENV,
+    })
+
+    try {
+      // Set *after* the worker started: under SHARE_ENV the two threads hold
+      // one `process.env`, so the worker sees this without being restarted.
+      // A copied environment would not, which is what makes this assert that
+      // SHARE_ENV took effect rather than merely that it was accepted.
+      process.env.TINYPOOL_TEST_SHARED = 'shared-after-start'
+
+      expect(await pool.run(readEnv('TINYPOOL_TEST_SHARED'))).toBe(
+        'shared-after-start'
+      )
+    } finally {
+      delete process.env.TINYPOOL_TEST_SHARED
+      await pool.destroy()
+    }
+  })
+
+  // `ProcessWorker` forks with `{ ...options.env }`, and spreading a symbol
+  // gives `{}` — so this combination would have started children with no
+  // environment at all beyond TINYPOOL_WORKER_ID: no PATH, no HOME.
+  test('refuses SHARE_ENV with runtime child_process', () => {
+    expect(
+      () =>
+        new Tinypool({
+          filename,
+          runtime: 'child_process',
+          env: SHARE_ENV,
+        })
+    ).toThrow(TypeError)
+
+    expect(
+      () =>
+        new Tinypool({
+          filename,
+          runtime: 'child_process',
+          env: SHARE_ENV,
+        })
+    ).toThrow(/SHARE_ENV/)
+  })
+
+  test('refuses recycling a SHARE_ENV pool onto child_process', async () => {
+    // The constructor guard alone is bypassable: this is the one path that
+    // moves an existing pool onto the runtime that cannot share.
+    const pool = new Tinypool({
+      filename,
+      runtime: 'worker_threads',
+      minThreads: 1,
+      maxThreads: 1,
+      env: SHARE_ENV,
+    })
+
+    await expect(
+      pool.recycleWorkers({ runtime: 'child_process' })
+    ).rejects.toThrow(/SHARE_ENV/)
+
+    await pool.destroy()
+  })
+
+  test('still allows recycling a SHARE_ENV pool within worker_threads', async () => {
+    // The control for the guard above: it must refuse the runtime that cannot
+    // share, not recycling in general.
+    const pool = new Tinypool({
+      filename,
+      runtime: 'worker_threads',
+      minThreads: 1,
+      maxThreads: 1,
+      env: SHARE_ENV,
+    })
+
+    await expect(
+      pool.recycleWorkers({ runtime: 'worker_threads' })
+    ).resolves.not.toThrow()
+
+    await pool.destroy()
+  })
+})


### PR DESCRIPTION
Fixes #136

Not a purposeful restriction as far as I can tell — `ThreadWorker` already passes `options` straight to `new Worker`, so both values worked at runtime and only the type refused them. `options.env` now mirrors `WorkerOptions['env']`:

```ts
env?: NodeJS.Dict<string> | typeof SHARE_ENV
```

in `Options` and in `TinypoolWorker['initialize']`. `process.env` is `Record<string, string | undefined>`, which is why the old `Record<string, string>` rejected it.

## The part that made this more than a type change

You wrote *"supporting SHARE_ENV might not always be possible"* — that's right, and it is worse than not possible. `ProcessWorker` forks with:

```ts
env: { ...options.env, TINYPOOL_WORKER_ID: … }
```

and `{ ...aSymbol }` is `{}`. So a `child_process` pool given `SHARE_ENV` would have started every child with **no environment beyond the worker id** — no `PATH`, no `HOME` — and no error. Widening the type alone would have made that reachable from a type-checking program.

`tsc` says so the moment the type admits a symbol, which is a nice confirmation rather than something I had to reason about:

```
src/runtime/process-worker.ts: error TS2698: Spread types may only be created
from object types.
```

So the combination is **refused, not approximated**. `assertEnvRuntime` throws a `TypeError` naming the fix, and it runs in two places:

- the **constructor**, for the obvious case;
- **`recycleWorkers`**, because it is the one path that moves an existing pool onto `child_process` — a constructor-only guard is bypassed by `pool.recycleWorkers({ runtime: 'child_process' })`.

`ProcessWorker` additionally throws if a symbol ever reaches it, so the invariant can't quietly decay back into an empty environment if a third call path appears.

## Verification

Seven tests in `test/env.test.ts`. The `SHARE_ENV` one asserts it **actually shares**, rather than merely that it was accepted: a variable set in the parent *after* the worker has started is read back through the pool, which a copied environment could not do.

Each guard was checked by removing it, and the type by reverting it:

| change | result |
|---|---|
| constructor guard removed | `refuses SHARE_ENV with runtime child_process` → **red** |
| `recycleWorkers` guard removed | `refuses recycling a SHARE_ENV pool onto child_process` → **red** |
| `env` reverted to `Record<string, string>` | the issue's own two errors, against this suite: `Type 'ProcessEnv' is not assignable…` and `Type 'symbol' is not assignable…` |

That last one is the reproduction: the new tests are exactly the code from the issue, so they stop compiling if the type regresses.

There's also a control — recycling a `SHARE_ENV` pool *within* `worker_threads` still succeeds — so the guard refuses the runtime that cannot share rather than refusing recycling in general.

**98 tests pass.** `npm run build`, `npm run typecheck` and `npm run lint` (`eslint --max-warnings=0`) are all clean.

## One open question for you

I refused `SHARE_ENV` + `child_process` rather than silently falling back to `process.env`, on the grounds that a pool asking to *share* an environment and getting a copy is a difference the caller would want to know about. If you'd rather it degrade quietly for `child_process` — or accept it and document the copy — say so and I'll change it; it's a one-line switch either way and it's your API.
