### PR TITLE
feat: accept a URL instance as filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _In case you need more tiny libraries like tinypool or tinyspy, please consider 
 import Tinypool from 'tinypool'
 
 const pool = new Tinypool({
-  filename: new URL('./worker.mjs', import.meta.url).href,
+  filename: new URL('./worker.mjs', import.meta.url),
 })
 const result = await pool.run({ a: 4, b: 6 })
 console.log(result) // Prints 10
@@ -55,7 +55,7 @@ import Tinypool from 'tinypool'
 import { MessageChannel } from 'node:worker_threads'
 
 const pool = new Tinypool({
-  filename: new URL('./worker.mjs', import.meta.url).href,
+  filename: new URL('./worker.mjs', import.meta.url),
 })
 const { port1, port2 } = new MessageChannel()
 const promise = pool.run({ port: port1 }, { transferList: [port1] })
@@ -98,7 +98,7 @@ import Tinypool from 'tinypool'
 
 const pool = new Tinypool({
   runtime: 'child_process',
-  filename: new URL('./worker.mjs', import.meta.url).href,
+  filename: new URL('./worker.mjs', import.meta.url),
 })
 const result = await pool.run({ a: 4, b: 6 })
 console.log(result) // Prints 10
@@ -124,7 +124,7 @@ import Tinypool from 'tinypool'
 
 const pool = new Tinypool({
   runtime: 'child_process',
-  filename: new URL('./worker.mjs', import.meta.url).href,
+  filename: new URL('./worker.mjs', import.meta.url),
 })
 
 const messages = []

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ class ArrayTaskQueue implements TaskQueue {
 }
 
 interface Options {
-  filename?: string | null
+  filename?: string | URL | null
   runtime?: 'worker_threads' | 'child_process'
   name?: string
   minThreads?: number
@@ -187,7 +187,7 @@ const kDefaultOptions: FilledOptions = {
 interface RunOptions {
   transferList?: TransferList
   channel?: TinypoolChannel
-  filename?: string | null
+  filename?: string | URL | null
   signal?: AbortSignalAny | null
   name?: string | null
   runtime?: Options['runtime']
@@ -195,7 +195,7 @@ interface RunOptions {
 
 interface FilledRunOptions extends RunOptions {
   transferList: TransferList | never
-  filename: string | null
+  filename: string | URL | null
   signal: AbortSignalAny | null
   name: string | null
 }
@@ -250,7 +250,14 @@ type TransferList = MessagePort extends {
   : never
 type TransferListItem = TransferList extends (infer T)[] ? T : never
 
-function maybeFileURLToPath(filename: string): string {
+function maybeFileURLToPath(filename: string | URL): string {
+  // A URL instance is normalised the same way the equivalent string is: a file: URL
+  // becomes a path, and any other scheme is passed through for the worker to import().
+  if (typeof filename !== 'string') {
+    return filename.protocol === 'file:'
+      ? fileURLToPath(filename)
+      : filename.href
+  }
   return filename.startsWith('file:')
     ? fileURLToPath(new URL(filename))
     : filename
@@ -929,7 +936,7 @@ class ThreadPool {
     if (name == null) {
       name = this.options.name
     }
-    if (typeof filename !== 'string') {
+    if (typeof filename !== 'string' && !(filename instanceof URL)) {
       return Promise.reject(Errors.FilenameNotProvided())
     }
     filename = maybeFileURLToPath(filename)

--- a/test/simple.test.ts
+++ b/test/simple.test.ts
@@ -143,6 +143,65 @@ test('filename can be a file:// URL to an ESM module', async () => {
   expect(result).toBe(42)
 })
 
+test('filename can be a URL instance', async () => {
+  const worker = new Tinypool({
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')),
+  })
+  const result = await worker.run('42')
+  expect(result).toBe(42)
+})
+
+test('filename can be a URL instance to an ESM module', async () => {
+  const worker = new Tinypool({
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')),
+  })
+  const result = await worker.run('42')
+  expect(result).toBe(42)
+})
+
+test('run() accepts a URL instance as filename', async () => {
+  const worker = new Tinypool()
+  const result = await worker.run('42', {
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')),
+  })
+  expect(result).toBe(42)
+})
+
+test('a URL instance overrides the pool filename per task', async () => {
+  const worker = new Tinypool({
+    filename: resolve(__dirname, 'fixtures/eval.js'),
+  })
+  const result = await worker.run('42', {
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/esm-export.mjs')),
+  })
+  expect(result).toBe(42)
+})
+
+test('filename can be a URL instance with runtime child_process', async () => {
+  const worker = new Tinypool({
+    filename: pathToFileURL(resolve(__dirname, 'fixtures/eval.js')),
+    runtime: 'child_process',
+  })
+  const result = await worker.run('42')
+  expect(result).toBe(42)
+})
+
+test('a non-file: URL instance is passed through to the worker', async () => {
+  const worker = new Tinypool({
+    filename: new URL('data:text/javascript,export default () => 42'),
+  })
+  const result = await worker.run(null)
+  expect(result).toBe(42)
+})
+
+test('run() rejects a filename that is neither string nor URL', async () => {
+  const worker = new Tinypool()
+  await expect(
+    // @ts-expect-error -- deliberately wrong type
+    worker.run('42', { filename: 42 })
+  ).rejects.toThrow('filename must be provided to run() or in options object')
+})
+
 test('named tasks work', async () => {
   const worker = new Tinypool({
     filename: resolve(__dirname, 'fixtures/multiple.js'),


### PR DESCRIPTION
Closes #109

`filename` accepted only a string, so a caller holding a `URL` had to unwrap it. The README does exactly that in every example:

```ts
filename: new URL('./worker.mjs', import.meta.url).href
```

A `file:` URL *string* was already normalised by `maybeFileURLToPath`, so the conversion existed and only the instance was refused.

## Approach

A `URL` is normalised the same way the equivalent string is — a `file:` URL becomes a path via `fileURLToPath`, any other scheme passes through as `.href` for the worker to `import()`. The two spellings stay exactly equivalent rather than growing a second code path.

```ts
function maybeFileURLToPath(filename: string | URL): string {
  if (typeof filename !== 'string') {
    return filename.protocol === 'file:'
      ? fileURLToPath(filename)
      : filename.href
  }
  return filename.startsWith('file:') ? fileURLToPath(new URL(filename)) : filename
}
```

@fisker suggested `filename instanceof URL ? filename.href : filename`. I went with `fileURLToPath` for the `file:` case instead, so a `URL` and its `.href` produce an identical result — `.href` alone would hand the worker a `file://` string where the string path gives a plain path, and would change behaviour on Windows, which @AriPerkkio flagged on the issue.

Three places needed the change:

- `Options.filename` and `RunOptions.filename` → `string | URL | null`
- `maybeFileURLToPath` → `string | URL`
- `runTask()` rejected anything failing `typeof filename === 'string'`, which would have refused a **per-task** URL even after the constructor accepted one

## Tests

Seven, covering the constructor, `run()`, a per-task URL overriding a string pool filename, the `child_process` runtime, a non-`file:` scheme, and that a filename which is neither string nor URL is still rejected.

Each change was verified by reverting it:

| reverted | result |
|---|---|
| `runTask` URL guard | 2 tests red |
| URL branch in `maybeFileURLToPath` | 6 tests red |
| the public types | 6 test lines stop compiling: `Type 'URL' is not assignable to type 'string'` |

That last one makes the tests a reproduction of the issue rather than only a check of the fix.

**98 tests pass**; `build`, `typecheck` and `lint` (`--max-warnings=0`) are clean. Verified on Node 24.21.0 (macOS arm64) — I don't have a Windows machine, so the `file:` path handling there rests on `fileURLToPath` rather than on my own testing.

I left the README's `.href` examples alone to keep the diff focused; happy to drop the `.href` in a follow-up if you'd like the docs to show the shorter form.